### PR TITLE
Update Experiment4.ipynb

### DIFF
--- a/book/docs/notebooks/Experiment4.ipynb
+++ b/book/docs/notebooks/Experiment4.ipynb
@@ -27,9 +27,7 @@
     "from cvx.simulator import FuturesPortfolio\n",
     "from cvx.simulator import interpolate\n",
     "\n",
-    "from tinycta.signal import *\n",
-    "\n",
-    "pd.options.plotting.backend = \"plotly\""
+    "from tinycta.signal import *\n"
    ]
   },
   {


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI


### What change is being made?

Remove unnecessary line setting pandas plotting backend to "plotly" in Experiment4.ipynb.

### Why are these changes being made?

The line setting pandas plotting backend was redundant and not used further in the notebook, simplifying the code by eliminating unused imports or settings. The notebook continues to function as intended without this line.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->