### PR TITLE
perf/refactor: faster Polars usage and Expr->Expr signal functions across all experiments

### DIFF
--- a/book/marimo/notebooks/Experiment1.py
+++ b/book/marimo/notebooks/Experiment1.py
@@ -24,7 +24,6 @@ with app.setup:
     from pathlib import Path
 
     import marimo as mo
-    import numpy as np
     import plotly.io as pio
     import polars as pl
 

--- a/book/marimo/notebooks/Experiment1.py
+++ b/book/marimo/notebooks/Experiment1.py
@@ -51,21 +51,8 @@ def _():
 
 
 @app.function
-def f(price, fast=32, slow=96):
-    """Calculate trading signals based on the difference between fast and slow moving averages.
-
-    Args:
-        price: Polars Series of price data
-        fast: Fast moving average period (default: 32)
-        slow: Slow moving average period (default: 96)
-
-    Returns:
-        Series of trading signals (-1, 0, or 1) based on the sign of the difference
-        between fast and slow moving averages
-    """
-    s = price.ewm_mean(com=slow, min_samples=100)
-    fast_ma = price.ewm_mean(com=fast, min_samples=100)
-    return (fast_ma - s).sign()
+def f(price: "pl.Expr", fast=32, slow=96) -> "pl.Expr":
+    return (price.ewm_mean(com=fast, min_samples=100) - price.ewm_mean(com=slow, min_samples=100)).sign()
 
 
 @app.cell

--- a/book/marimo/notebooks/Experiment1.py
+++ b/book/marimo/notebooks/Experiment1.py
@@ -114,19 +114,6 @@ def _(portfolio):
     return
 
 
-@app.cell(hide_code=True)
-def _():
-    mo.md(
-        r"""
-    cvxSimulator can construct portfolio objects. Those objects will
-    expose functionality and attributes supporting all analytics.
-    There are two types of portfolio -- EquityPortfolio and FuturesPortfolio.
-    We start with the FuturesPortfolio. The most simple use-case
-    is when we have computed all desirec cash-positions
-    """
-    )
-    return
-
 
 if __name__ == "__main__":
     app.run()

--- a/book/marimo/notebooks/Experiment1.py
+++ b/book/marimo/notebooks/Experiment1.py
@@ -80,11 +80,9 @@ def _():
 
 @app.cell
 def _(fast, slow):
-    assets = [c for c in prices.columns if c != date_col]
-    pos = prices.with_columns([
-        (5e6 * f(prices[asset], fast=fast.value, slow=slow.value).fill_null(0.0)).alias(asset)
-        for asset in assets
-    ])
+    pos = prices.with_columns(
+        f(pl.all().exclude(date_col), fast=fast.value, slow=slow.value).fill_null(0.0) * 5e6
+    )
     return (pos,)
 
 

--- a/book/marimo/notebooks/Experiment2.py
+++ b/book/marimo/notebooks/Experiment2.py
@@ -24,7 +24,6 @@ with app.setup:
     from pathlib import Path
 
     import marimo as mo
-    import numpy as np
     import plotly.io as pio
     import polars as pl
 
@@ -45,7 +44,7 @@ with app.setup:
 
 
 @app.cell(hide_code=True)
-def _(mo):
+def _():
     mo.md(r"""# CTA 2.0""")
     return
 
@@ -58,12 +57,10 @@ def f(price: "pl.Expr", fast=32, slow=96, volatility=32) -> "pl.Expr":
 
 @app.cell
 def _():
-    # Create sliders using marimo's UI components
     fast = mo.ui.slider(4, 192, step=4, value=32, label="Fast Moving Average")
     slow = mo.ui.slider(4, 192, step=4, value=96, label="Slow Moving Average")
     vola = mo.ui.slider(4, 192, step=4, value=32, label="Volatility")
 
-    # Display the sliders in a vertical stack
     mo.vstack([fast, slow, vola])
 
     return fast, slow, vola

--- a/book/marimo/notebooks/Experiment2.py
+++ b/book/marimo/notebooks/Experiment2.py
@@ -95,11 +95,9 @@ def _():
 
 @app.cell
 def _(fast, slow, vola):
-    assets = [c for c in prices.columns if c != date_col]
-    pos = prices.with_columns([
-        (1e5 * f(prices[asset], fast=fast.value, slow=slow.value, volatility=vola.value).fill_null(0.0)).alias(asset)
-        for asset in assets
-    ])
+    pos = prices.with_columns(
+        f(pl.all().exclude(date_col), fast=fast.value, slow=slow.value, volatility=vola.value).fill_null(0.0) * 1e5
+    )
     portfolio = Portfolio.from_cash_position(prices=prices, cash_position=pos, aum=1e8)
     _nav = portfolio.nav_accumulated["NAV_accumulated"].pct_change().drop_nulls()
     print(float(_nav.mean() / _nav.std(ddof=1) * portfolio.data._periods_per_year**0.5))

--- a/book/marimo/notebooks/Experiment2.py
+++ b/book/marimo/notebooks/Experiment2.py
@@ -50,14 +50,6 @@ def _(mo):
     return
 
 
-@app.cell
-def _():
-    import warnings
-
-    # Suppress noisy warnings
-    warnings.simplefilter(action="ignore", category=FutureWarning)
-    return
-
 
 @app.function
 def f(price: "pl.Expr", fast=32, slow=96, volatility=32) -> "pl.Expr":
@@ -94,7 +86,6 @@ def _():
         r"""
     * This is a **univariate** trading system, we map the (real) price of an asset to its (cash)position
     * Only 3 **free parameters** used here.
-    * Only 4 lines of code
     * Scaling the bet-size by volatility has improved the situation.
     """
     )

--- a/book/marimo/notebooks/Experiment2.py
+++ b/book/marimo/notebooks/Experiment2.py
@@ -60,24 +60,8 @@ def _():
 
 
 @app.function
-def f(price, fast=32, slow=96, volatility=32):
-    """Calculate volatility-scaled trading signals based on moving averages.
-
-    Args:
-        price: Polars Series of price data
-        fast: Fast moving average period (default: 32)
-        slow: Slow moving average period (default: 96)
-        volatility: Lookback period for volatility calculation (default: 32)
-
-    Returns:
-        Series of trading signals scaled by inverse volatility, providing
-        larger positions during low volatility periods and smaller positions
-        during high volatility periods
-    """
-    s = price.ewm_mean(com=slow, min_samples=300)
-    fast_ma = price.ewm_mean(com=fast, min_samples=300)
-    std = price.pct_change().ewm_std(com=volatility, min_samples=300)
-    return (fast_ma - s).sign() / std
+def f(price: "pl.Expr", fast=32, slow=96, volatility=32) -> "pl.Expr":
+    return (price.ewm_mean(com=fast, min_samples=300) - price.ewm_mean(com=slow, min_samples=300)).sign() / price.pct_change().ewm_std(com=volatility, min_samples=300)
 
 
 @app.cell

--- a/book/marimo/notebooks/Experiment3.py
+++ b/book/marimo/notebooks/Experiment3.py
@@ -98,16 +98,12 @@ def _():
     return
 
 
-@app.cell
-def _():
-    # take two moving averages and apply tanh
-    def f(price: "pl.DataFrame", slow=96, fast=32, vola=96, clip=3):
-        price_adj = price.with_columns(vol_adj(pl.all(), vola=vola, clip=clip, min_samples=300).cum_sum())
-        mu = price_adj.with_columns(osc(pl.all(), fast=fast, slow=slow).tanh())
-        vol = price.select(pl.all().pct_change().ewm_std(com=slow, min_samples=300))
-        return mu.with_columns([pl.col(c) / vol[c] for c in price.columns])
-
-    return (f,)
+@app.function
+def f(price: "pl.Expr", slow=96, fast=32, vola=96, clip=3) -> "pl.Expr":
+    price_adj = vol_adj(price, vola=vola, clip=clip, min_samples=300).cum_sum()
+    mu = osc(price_adj, fast=fast, slow=slow).tanh()
+    vol = price.pct_change().ewm_std(com=slow, min_samples=300)
+    return mu / vol
 
 
 @app.cell
@@ -125,13 +121,14 @@ def _():
 
 
 @app.cell
-def _(f, fast, slow, vola, winsor):
-    assets = [c for c in prices.columns if c != date_col]
+def _(fast, slow, vola, winsor):
     prices_only = prices.drop(date_col)
-    pos_values = f(prices_only, fast=fast.value, slow=slow.value, vola=vola.value, clip=winsor.value)
     pos = pl.concat([
         prices.select(date_col),
-        pos_values.select((pl.all() * 1e5).fill_nan(0.0).fill_null(0.0))
+        prices_only.select(
+            (f(pl.all(), fast=fast.value, slow=slow.value, vola=vola.value, clip=winsor.value) * 1e5)
+            .fill_nan(0.0).fill_null(0.0)
+        )
     ], how="horizontal")
     portfolio = Portfolio.from_cash_position(prices=prices, cash_position=pos, aum=1e8)
     _nav = portfolio.nav_accumulated["NAV_accumulated"].pct_change().drop_nulls()

--- a/book/marimo/notebooks/Experiment3.py
+++ b/book/marimo/notebooks/Experiment3.py
@@ -102,16 +102,10 @@ def _():
 def _():
     # take two moving averages and apply tanh
     def f(price: "pl.DataFrame", slow=96, fast=32, vola=96, clip=3):
-        cols = price.columns
-        # construct a fake-price with homoscedastic returns using vol_adj from TinyCTA
-        price_adj = price.with_columns([vol_adj(pl.col(c), vola=vola, clip=clip, min_samples=300).cum_sum() for c in cols])
-        # compute mu
-        osc_df = price_adj.with_columns([osc(pl.col(c), fast=fast, slow=slow) for c in cols])
-        mu = osc_df.with_columns([pl.col(c).tanh() for c in osc_df.columns])
-        vol = price.with_columns([
-            pl.col(c).pct_change().ewm_std(com=slow, min_samples=300) for c in price.columns
-        ])
-        return pl.DataFrame({c: mu[c] / vol[c] for c in price.columns})
+        price_adj = price.with_columns(vol_adj(pl.all(), vola=vola, clip=clip, min_samples=300).cum_sum())
+        mu = price_adj.with_columns(osc(pl.all(), fast=fast, slow=slow).tanh())
+        vol = price.select(pl.all().pct_change().ewm_std(com=slow, min_samples=300))
+        return mu.with_columns([pl.col(c) / vol[c] for c in price.columns])
 
     return (f,)
 
@@ -135,10 +129,10 @@ def _(f, fast, slow, vola, winsor):
     assets = [c for c in prices.columns if c != date_col]
     prices_only = prices.drop(date_col)
     pos_values = f(prices_only, fast=fast.value, slow=slow.value, vola=vola.value, clip=winsor.value)
-    pos = pl.DataFrame(
-        {date_col: prices[date_col]}
-        | {col: (pos_values[col] * 1e5).fill_nan(0.0).fill_null(0.0).to_list() for col in assets}
-    )
+    pos = pl.concat([
+        prices.select(date_col),
+        pos_values.select((pl.all() * 1e5).fill_nan(0.0).fill_null(0.0))
+    ], how="horizontal")
     portfolio = Portfolio.from_cash_position(prices=prices, cash_position=pos, aum=1e8)
     _nav = portfolio.nav_accumulated["NAV_accumulated"].pct_change().drop_nulls()
     print(float(_nav.mean() / _nav.std(ddof=1) * portfolio.data._periods_per_year**0.5))

--- a/book/marimo/notebooks/Experiment3.py
+++ b/book/marimo/notebooks/Experiment3.py
@@ -26,7 +26,6 @@ with app.setup:
     from pathlib import Path
 
     import marimo as mo
-    import numpy as np
     import plotly.io as pio
     import polars as pl
 
@@ -108,13 +107,11 @@ def f(price: "pl.Expr", slow=96, fast=32, vola=96, clip=3) -> "pl.Expr":
 
 @app.cell
 def _():
-    # Create sliders using marimo's UI components
     fast = mo.ui.slider(4, 192, step=4, value=32, label="Fast Moving Average")
     slow = mo.ui.slider(4, 192, step=4, value=96, label="Slow Moving Average")
     vola = mo.ui.slider(4, 192, step=4, value=32, label="Volatility")
     winsor = mo.ui.slider(1.0, 6.0, step=0.1, value=4.2, label="Winsorizing")
 
-    # Display the sliders in a vertical stack
     mo.vstack([fast, slow, vola, winsor])
 
     return fast, slow, vola, winsor

--- a/book/marimo/notebooks/Experiment4.py
+++ b/book/marimo/notebooks/Experiment4.py
@@ -72,16 +72,10 @@ def _():
 def _(fast, slow, vola, winsor):
     assets = [c for c in prices.columns if c != date_col]
     prices_only = prices.drop(date_col)
-    cols = prices_only.columns
 
-    adj_cs = prices_only.with_columns([vol_adj(pl.col(c), vola=vola.value, clip=winsor.value, min_samples=300).cum_sum() for c in cols])
-    osc_df = adj_cs.with_columns([osc(pl.col(c), fast=fast.value, slow=slow.value) for c in cols])
-    mu = osc_df.with_columns([pl.col(c).tanh() for c in osc_df.columns])
-
-    volax = prices_only.with_columns([
-        pl.col(c).fill_nan(None).pct_change().ewm_std(com=vola.value, min_samples=vola.value)
-        for c in prices_only.columns
-    ])
+    adj_cs = prices_only.with_columns(vol_adj(pl.all(), vola=vola.value, clip=winsor.value, min_samples=300).cum_sum())
+    mu = adj_cs.with_columns(osc(pl.all(), fast=fast.value, slow=slow.value).tanh())
+    volax = prices_only.select(pl.all().fill_nan(None).pct_change().ewm_std(com=vola.value, min_samples=vola.value))
 
     mu_np = mu.to_numpy()
     volax_np = volax.to_numpy()
@@ -92,10 +86,10 @@ def _(fast, slow, vola, winsor):
     risk_scaled_np = mu_np / euclid_norm
 
     pos_np = np.nan_to_num(5e5 * risk_scaled_np / volax_np, nan=0.0)
-    pos = pl.DataFrame(
-        {date_col: prices[date_col]}
-        | {col: pos_np[:, i].tolist() for i, col in enumerate(assets)}
-    )
+    pos = pl.concat([
+        prices.select(date_col),
+        pl.from_numpy(pos_np, schema={col: pl.Float64 for col in assets})
+    ], how="horizontal")
     portfolio = Portfolio.from_cash_position(prices=prices, cash_position=pos, aum=1e8)
     _nav = portfolio.nav_accumulated["NAV_accumulated"].pct_change().drop_nulls()
     print(float(_nav.mean() / _nav.std(ddof=1) * portfolio.data._periods_per_year**0.5))

--- a/book/marimo/notebooks/Experiment4.py
+++ b/book/marimo/notebooks/Experiment4.py
@@ -61,13 +61,11 @@ def f(price: "pl.Expr", fast=32, slow=96, vola=32, clip=4.2) -> "pl.Expr":
 
 @app.cell
 def _():
-    # Create sliders using marimo's UI components
     fast = mo.ui.slider(4, 192, step=4, value=32, label="Fast Moving Average")
     slow = mo.ui.slider(4, 192, step=4, value=96, label="Slow Moving Average")
     vola = mo.ui.slider(4, 192, step=4, value=32, label="Volatility")
     winsor = mo.ui.slider(1.0, 6.0, step=0.1, value=4.2, label="Winsorizing")
 
-    # Display the sliders in a vertical stack
     mo.vstack([fast, slow, vola, winsor])
 
     return fast, slow, vola, winsor

--- a/book/marimo/notebooks/Experiment4.py
+++ b/book/marimo/notebooks/Experiment4.py
@@ -80,8 +80,6 @@ def _(fast, slow, vola, winsor):
 
     mu_np = prices_only.select(f(pl.all(), fast=fast.value, slow=slow.value, vola=vola.value, clip=winsor.value)).to_numpy()
     volax_np = prices_only.select(pl.all().fill_nan(None).pct_change().ewm_std(com=vola.value, min_samples=vola.value)).to_numpy()
-    # nansum matches pandas DataFrame.sum(axis=1, skipna=True): assets with no data
-    # for a given row contribute 0 rather than propagating NaN into the norm
     euclid_norm = np.sqrt(np.nansum(mu_np ** 2, axis=1, keepdims=True))
     euclid_norm[euclid_norm == 0] = np.nan
     risk_scaled_np = mu_np / euclid_norm

--- a/book/marimo/notebooks/Experiment4.py
+++ b/book/marimo/notebooks/Experiment4.py
@@ -54,6 +54,11 @@ def _():
     return
 
 
+@app.function
+def f(price: "pl.Expr", fast=32, slow=96, vola=32, clip=4.2) -> "pl.Expr":
+    return osc(vol_adj(price, vola=vola, clip=clip, min_samples=300).cum_sum(), fast=fast, slow=slow).tanh()
+
+
 @app.cell
 def _():
     # Create sliders using marimo's UI components
@@ -73,12 +78,8 @@ def _(fast, slow, vola, winsor):
     assets = [c for c in prices.columns if c != date_col]
     prices_only = prices.drop(date_col)
 
-    adj_cs = prices_only.with_columns(vol_adj(pl.all(), vola=vola.value, clip=winsor.value, min_samples=300).cum_sum())
-    mu = adj_cs.with_columns(osc(pl.all(), fast=fast.value, slow=slow.value).tanh())
-    volax = prices_only.select(pl.all().fill_nan(None).pct_change().ewm_std(com=vola.value, min_samples=vola.value))
-
-    mu_np = mu.to_numpy()
-    volax_np = volax.to_numpy()
+    mu_np = prices_only.select(f(pl.all(), fast=fast.value, slow=slow.value, vola=vola.value, clip=winsor.value)).to_numpy()
+    volax_np = prices_only.select(pl.all().fill_nan(None).pct_change().ewm_std(com=vola.value, min_samples=vola.value)).to_numpy()
     # nansum matches pandas DataFrame.sum(axis=1, skipna=True): assets with no data
     # for a given row contribute 0 rather than propagating NaN into the norm
     euclid_norm = np.sqrt(np.nansum(mu_np ** 2, axis=1, keepdims=True))

--- a/book/marimo/notebooks/Experiment5.py
+++ b/book/marimo/notebooks/Experiment5.py
@@ -56,6 +56,11 @@ def _():
     return
 
 
+@app.function
+def f(price: "pl.Expr", fast=32, slow=96, vola=32, clip=4.2) -> "pl.Expr":
+    return osc(vol_adj(price, vola=vola, clip=clip, min_samples=300).cum_sum(), fast=fast, slow=slow).tanh()
+
+
 @app.cell
 def _():
     # Create sliders using marimo's UI components
@@ -109,7 +114,7 @@ def _(corr, shrinkage, vola, winsor):
     for _k in range(n_assets):
         cor_3d[_var[:, _k] > 0, _k, _k] = 1.0
 
-    mu = returns_adj.with_columns(pl.all().cum_sum()).with_columns(osc(pl.all(), fast=32, slow=96).tanh()).to_numpy()
+    mu = prices_only.select(f(pl.all(), fast=32, slow=96, vola=vola.value, clip=winsor.value)).to_numpy()
     vo = prices_only.select(
         pl.all().fill_nan(None).pct_change().ewm_std(com=vola.value, min_samples=int(vola.value))
     ).to_numpy()

--- a/book/marimo/notebooks/Experiment5.py
+++ b/book/marimo/notebooks/Experiment5.py
@@ -63,7 +63,6 @@ def f(price: "pl.Expr", fast=32, slow=96, vola=32, clip=4.2) -> "pl.Expr":
 
 @app.cell
 def _():
-    # Create sliders using marimo's UI components
     fast = mo.ui.slider(4, 192, step=4, value=32, label="Fast Moving Average")
     slow = mo.ui.slider(4, 192, step=4, value=96, label="Slow Moving Average")
     vola = mo.ui.slider(4, 192, step=4, value=32, label="Volatility")
@@ -71,7 +70,6 @@ def _():
     corr = mo.ui.slider(50, 500, step=10, value=200, label="Correlation")
     shrinkage = mo.ui.slider(0.0, 1.0, step=0.05, value=0.5, label="Shrinkage")
 
-    # Display the sliders in a vertical stack
     mo.vstack([fast, slow, vola, winsor, corr, shrinkage])
 
     return corr, shrinkage, vola, winsor
@@ -151,7 +149,7 @@ def _():
     mo.md(
         r"""
     # Conclusions
-    * Dramatic relativ improvements observable despite using the same signals as in previous Experiment.
+    * Dramatic relative improvements observable despite using the same signals as in previous Experiment.
     * Main difference here is to take advantage of cross-correlations in the risk measurement.
     * Possible to add constraints on individual assets or groups of them.
     * Possible to reflect trading costs in objective with regularization terms (Ridge, Lars, Elastic Nets, ...)

--- a/book/marimo/notebooks/Experiment5.py
+++ b/book/marimo/notebooks/Experiment5.py
@@ -80,13 +80,13 @@ def _(corr, shrinkage, vola, winsor):
     n_rows = len(prices_only)
     correlation = corr.value
 
-    returns_adj = prices_only.with_columns([vol_adj(pl.col(c), vola=vola.value, clip=winsor.value, min_samples=300) for c in assets])
+    returns_adj = prices_only.with_columns(vol_adj(pl.all(), vola=vola.value, clip=winsor.value, min_samples=300))
 
     # EWM correlation (DCC by Engle)
     # cov_t(i,j) = ewm_t(r_i * r_j) - ewm_t(r_i) * ewm_t(r_j)
-    ewm_means_np = returns_adj.select([
-        pl.col(c).ewm_mean(com=correlation, min_samples=int(correlation)) for c in assets
-    ]).to_numpy()
+    ewm_means_np = returns_adj.select(
+        pl.all().ewm_mean(com=correlation, min_samples=int(correlation))
+    ).to_numpy()
 
     pair_indices = [(i, j) for i in range(n_assets) for j in range(i, n_assets)]
     ewm_prod_np = returns_adj.select([
@@ -109,13 +109,10 @@ def _(corr, shrinkage, vola, winsor):
     for _k in range(n_assets):
         cor_3d[_var[:, _k] > 0, _k, _k] = 1.0
 
-    adj_cs = returns_adj.with_columns([pl.col(c).cum_sum() for c in assets])
-    osc_df = adj_cs.with_columns([osc(pl.col(c), fast=32, slow=96) for c in assets])
-    mu = osc_df.with_columns([pl.col(c).tanh() for c in osc_df.columns]).to_numpy()
-    vo = prices_only.with_columns([
-        pl.col(c).fill_nan(None).pct_change().ewm_std(com=vola.value, min_samples=int(vola.value))
-        for c in assets
-    ]).to_numpy()
+    mu = returns_adj.with_columns(pl.all().cum_sum()).with_columns(osc(pl.all(), fast=32, slow=96).tanh()).to_numpy()
+    vo = prices_only.select(
+        pl.all().fill_nan(None).pct_change().ewm_std(com=vola.value, min_samples=int(vola.value))
+    ).to_numpy()
 
     prices_np = prices_only.to_numpy()
     pos_matrix = np.zeros((n_rows, n_assets))
@@ -134,10 +131,10 @@ def _(corr, shrinkage, vola, winsor):
         _risk_pos = solve(_matrix, _expected_mu) / _norm
         pos_matrix[_n, _mask] = np.nan_to_num(1e6 * _risk_pos / _expected_vo, nan=0.0)
 
-    pos = pl.DataFrame(
-        {date_col: prices[date_col]}
-        | {col: pos_matrix[:, i].tolist() for i, col in enumerate(assets)}
-    )
+    pos = pl.concat([
+        prices.select(date_col),
+        pl.from_numpy(pos_matrix, schema={col: pl.Float64 for col in assets})
+    ], how="horizontal")
     portfolio = Portfolio.from_cash_position(prices=prices, cash_position=pos, aum=1e8)
     _nav = portfolio.nav_accumulated["NAV_accumulated"].pct_change().drop_nulls()
     print(float(_nav.mean() / _nav.std(ddof=1) * portfolio.data._periods_per_year**0.5))


### PR DESCRIPTION
## Summary
- Replace per-column Polars loops with `pl.all()` and `pl.from_numpy` across all experiments for faster execution
- Refactor signal function `f` to `pl.Expr → pl.Expr` in all experiments, enabling direct composition with `pl.all()`
- Remove stale `cvxSimulator` markdown cell from Experiment1, unused `warnings` cell from Experiment2, and stale pandas reference from Experiment4
- Drop unused `numpy` imports from Exp1–3, remove obvious slider comments from Exp2–5, fix `mo` parameter inconsistency in Exp2, and fix typo in Exp5 conclusions

## Test plan
- [ ] `make test` passes (6/6 Sharpe ratio baselines hold within 1e-6 tolerance)
- [ ] Notebooks run interactively in Marimo without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)