### PR TITLE
bump jquantstats to v0.8.3 and use expr-based interface

### DIFF
--- a/book/marimo/notebooks/Experiment1.py
+++ b/book/marimo/notebooks/Experiment1.py
@@ -5,7 +5,7 @@
 #     "numpy==2.4.4",
 #     "plotly==6.7.0",
 #     "polars==1.39.3",
-#     "jquantstats==0.8.2"
+#     "jquantstats==0.8.3"
 # ]
 # ///
 
@@ -69,11 +69,6 @@ def _(fast, slow):
     pos = prices.with_columns(
         f(pl.all().exclude(date_col), fast=fast.value, slow=slow.value).fill_null(0.0) * 5e6
     )
-    return (pos,)
-
-
-@app.cell
-def _(pos):
     portfolio = Portfolio.from_cash_position(prices=prices, cash_position=pos, aum=1e8)
     _nav = portfolio.nav_accumulated["NAV_accumulated"].pct_change().drop_nulls()
     print(float(_nav.mean() / _nav.std(ddof=1) * portfolio.data._periods_per_year**0.5))

--- a/book/marimo/notebooks/Experiment1.py
+++ b/book/marimo/notebooks/Experiment1.py
@@ -66,10 +66,11 @@ def _():
 
 @app.cell
 def _(fast, slow):
-    pos = prices.with_columns(
-        f(pl.all().exclude(date_col), fast=fast.value, slow=slow.value).fill_null(0.0) * 5e6
+    portfolio = Portfolio.from_cash_position(
+        prices=prices,
+        cash_position=f(pl.all().exclude(date_col), fast=fast.value, slow=slow.value).fill_null(0.0) * 5e6,
+        aum=1e8,
     )
-    portfolio = Portfolio.from_cash_position(prices=prices, cash_position=pos, aum=1e8)
     _nav = portfolio.nav_accumulated["NAV_accumulated"].pct_change().drop_nulls()
     print(float(_nav.mean() / _nav.std(ddof=1) * portfolio.data._periods_per_year**0.5))
     return (portfolio,)

--- a/book/marimo/notebooks/Experiment2.py
+++ b/book/marimo/notebooks/Experiment2.py
@@ -70,7 +70,15 @@ def _():
 def _(fast, slow, vola):
     portfolio = Portfolio.from_cash_position(
         prices=prices,
-        cash_position=f(pl.all().exclude(date_col), fast=fast.value, slow=slow.value, volatility=vola.value).fill_null(0.0) * 1e5,
+        cash_position=(
+            f(
+                pl.all().exclude(date_col),
+                fast=fast.value,
+                slow=slow.value,
+                volatility=vola.value,
+            ).fill_null(0.0)
+            * 1e5
+        ),
         aum=1e8,
     )
     _nav = portfolio.nav_accumulated["NAV_accumulated"].pct_change().drop_nulls()

--- a/book/marimo/notebooks/Experiment2.py
+++ b/book/marimo/notebooks/Experiment2.py
@@ -68,10 +68,11 @@ def _():
 
 @app.cell
 def _(fast, slow, vola):
-    pos = prices.with_columns(
-        f(pl.all().exclude(date_col), fast=fast.value, slow=slow.value, volatility=vola.value).fill_null(0.0) * 1e5
+    portfolio = Portfolio.from_cash_position(
+        prices=prices,
+        cash_position=f(pl.all().exclude(date_col), fast=fast.value, slow=slow.value, volatility=vola.value).fill_null(0.0) * 1e5,
+        aum=1e8,
     )
-    portfolio = Portfolio.from_cash_position(prices=prices, cash_position=pos, aum=1e8)
     _nav = portfolio.nav_accumulated["NAV_accumulated"].pct_change().drop_nulls()
     print(float(_nav.mean() / _nav.std(ddof=1) * portfolio.data._periods_per_year**0.5))
     return (portfolio,)

--- a/book/marimo/notebooks/Experiment2.py
+++ b/book/marimo/notebooks/Experiment2.py
@@ -5,7 +5,7 @@
 #     "numpy==2.4.4",
 #     "plotly==6.7.0",
 #     "polars==1.39.3",
-#     "jquantstats==0.8.2"
+#     "jquantstats==0.8.3"
 # ]
 # ///
 

--- a/book/marimo/notebooks/Experiment3.py
+++ b/book/marimo/notebooks/Experiment3.py
@@ -121,7 +121,16 @@ def _():
 def _(fast, slow, vola, winsor):
     portfolio = Portfolio.from_cash_position(
         prices=prices,
-        cash_position=(f(pl.all().exclude(date_col), fast=fast.value, slow=slow.value, vola=vola.value, clip=winsor.value) * 1e5).fill_nan(0.0).fill_null(0.0),
+        cash_position=(
+            f(
+                pl.all().exclude(date_col),
+                fast=fast.value,
+                slow=slow.value,
+                vola=vola.value,
+                clip=winsor.value,
+            )
+            * 1e5
+        ).fill_nan(0.0).fill_null(0.0),
         aum=1e8,
     )
     _nav = portfolio.nav_accumulated["NAV_accumulated"].pct_change().drop_nulls()

--- a/book/marimo/notebooks/Experiment3.py
+++ b/book/marimo/notebooks/Experiment3.py
@@ -119,15 +119,11 @@ def _():
 
 @app.cell
 def _(fast, slow, vola, winsor):
-    prices_only = prices.drop(date_col)
-    pos = pl.concat([
-        prices.select(date_col),
-        prices_only.select(
-            (f(pl.all(), fast=fast.value, slow=slow.value, vola=vola.value, clip=winsor.value) * 1e5)
-            .fill_nan(0.0).fill_null(0.0)
-        )
-    ], how="horizontal")
-    portfolio = Portfolio.from_cash_position(prices=prices, cash_position=pos, aum=1e8)
+    portfolio = Portfolio.from_cash_position(
+        prices=prices,
+        cash_position=(f(pl.all().exclude(date_col), fast=fast.value, slow=slow.value, vola=vola.value, clip=winsor.value) * 1e5).fill_nan(0.0).fill_null(0.0),
+        aum=1e8,
+    )
     _nav = portfolio.nav_accumulated["NAV_accumulated"].pct_change().drop_nulls()
     print(float(_nav.mean() / _nav.std(ddof=1) * portfolio.data._periods_per_year**0.5))
     return (portfolio,)

--- a/book/marimo/notebooks/Experiment3.py
+++ b/book/marimo/notebooks/Experiment3.py
@@ -5,7 +5,7 @@
 #     "numpy==2.4.4",
 #     "plotly==6.7.0",
 #     "polars==1.39.3",
-#     "jquantstats==0.8.2",
+#     "jquantstats==0.8.3",
 #     "tinycta==0.12.2"
 # ]
 # ///

--- a/book/marimo/notebooks/Experiment4.py
+++ b/book/marimo/notebooks/Experiment4.py
@@ -83,11 +83,14 @@ def _(fast, slow, vola, winsor):
     risk_scaled_np = mu_np / euclid_norm
 
     pos_np = np.nan_to_num(5e5 * risk_scaled_np / volax_np, nan=0.0)
-    pos = pl.concat([
-        prices.select(date_col),
-        pl.from_numpy(pos_np, schema={col: pl.Float64 for col in assets})
-    ], how="horizontal")
-    portfolio = Portfolio.from_cash_position(prices=prices, cash_position=pos, aum=1e8)
+    portfolio = Portfolio.from_cash_position(
+        prices=prices,
+        cash_position=pl.concat([
+            prices.select(date_col),
+            pl.from_numpy(pos_np, schema={col: pl.Float64 for col in assets})
+        ], how="horizontal"),
+        aum=1e8,
+    )
     _nav = portfolio.nav_accumulated["NAV_accumulated"].pct_change().drop_nulls()
     print(float(_nav.mean() / _nav.std(ddof=1) * portfolio.data._periods_per_year**0.5))
     return (portfolio,)

--- a/book/marimo/notebooks/Experiment4.py
+++ b/book/marimo/notebooks/Experiment4.py
@@ -5,7 +5,7 @@
 #     "numpy==2.4.4",
 #     "plotly==6.7.0",
 #     "polars==1.39.3",
-#     "jquantstats==0.8.2",
+#     "jquantstats==0.8.3",
 #     "tinycta==0.12.2"
 # ]
 # ///

--- a/book/marimo/notebooks/Experiment5.py
+++ b/book/marimo/notebooks/Experiment5.py
@@ -134,11 +134,14 @@ def _(corr, shrinkage, vola, winsor):
         _risk_pos = solve(_matrix, _expected_mu) / _norm
         pos_matrix[_n, _mask] = np.nan_to_num(1e6 * _risk_pos / _expected_vo, nan=0.0)
 
-    pos = pl.concat([
-        prices.select(date_col),
-        pl.from_numpy(pos_matrix, schema={col: pl.Float64 for col in assets})
-    ], how="horizontal")
-    portfolio = Portfolio.from_cash_position(prices=prices, cash_position=pos, aum=1e8)
+    portfolio = Portfolio.from_cash_position(
+        prices=prices,
+        cash_position=pl.concat([
+            prices.select(date_col),
+            pl.from_numpy(pos_matrix, schema={col: pl.Float64 for col in assets})
+        ], how="horizontal"),
+        aum=1e8,
+    )
     _nav = portfolio.nav_accumulated["NAV_accumulated"].pct_change().drop_nulls()
     print(float(_nav.mean() / _nav.std(ddof=1) * portfolio.data._periods_per_year**0.5))
     return (portfolio,)

--- a/book/marimo/notebooks/Experiment5.py
+++ b/book/marimo/notebooks/Experiment5.py
@@ -5,7 +5,7 @@
 #     "numpy==2.4.4",
 #     "plotly==6.7.0",
 #     "polars==1.39.3",
-#     "jquantstats==0.8.2",
+#     "jquantstats==0.8.3",
 #     "tinycta==0.12.2"
 # ]
 # ///

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "numpy>=2.4.4",
     "polars>=1.39.3",
     "plotly>=6.7.0",
-    "jquantstats>=0.8.2",
+    "jquantstats>=0.8.3",
     "tinycta>=0.12.2",
 ]
 classifiers = [


### PR DESCRIPTION
## Summary
- Bump `jquantstats` to `>=0.8.3` in `pyproject.toml` and `==0.8.3` in all notebooks
- Refactor Experiments 1–3 to pass a `pl.Expr` directly to `Portfolio.from_cash_position`, removing the intermediate `pos` DataFrame
- Inline `pos` into `from_cash_position` for Experiments 4 and 5 (NumPy-derived positions cannot be expressed as a Polars expression)

## Test plan
- [ ] Run each notebook and verify portfolio snapshots render correctly
- [ ] Confirm Sharpe ratio output is unchanged across all experiments

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated jquantstats dependency from version 0.8.2 to 0.8.3 across the project and experiment notebooks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tschm/cs/pull/396)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->