### PR TITLE
refactor(notebooks): extract shared preamble into preamble.py

### DIFF
--- a/book/marimo/notebooks/Experiment1.py
+++ b/book/marimo/notebooks/Experiment1.py
@@ -24,13 +24,14 @@ with app.setup:
     import sys
     from pathlib import Path
 
-    import polars as pl
     import marimo as mo
-    from jquantstats import Portfolio, interpolate
+    import polars as pl
+    from jquantstats import Portfolio
 
     sys.path.insert(0, str(Path(__file__).parent))
 
-    from preamble import load_prices
+    from preamble import date_col, load_prices
+
     prices = load_prices(__file__)
 
 

--- a/book/marimo/notebooks/Experiment1.py
+++ b/book/marimo/notebooks/Experiment1.py
@@ -21,26 +21,17 @@ __generated_with = "0.23.1"
 app = marimo.App()
 
 with app.setup:
+    import sys
     from pathlib import Path
 
-    import marimo as mo
-    import plotly.io as pio
     import polars as pl
-
+    import marimo as mo
     from jquantstats import Portfolio, interpolate
 
-    # Ensure Plotly works with Marimo
-    pio.renderers.default = "plotly_mimetype"
+    sys.path.insert(0, str(Path(__file__).parent))
 
-    path = Path(__file__).parent / "public" / "Prices_hashed.csv"
-
-    date_col = "date"
-
-    dframe = pl.read_csv(str(path), try_parse_dates=True)
-
-    dframe = dframe.with_columns(pl.col(date_col).cast(pl.Datetime("ns")))
-    dframe = dframe.with_columns([pl.col(col).cast(pl.Float64) for col in dframe.columns if col != date_col])
-    prices = interpolate(dframe)
+    from preamble import load_prices
+    prices = load_prices(__file__)
 
 
 @app.cell(hide_code=True)

--- a/book/marimo/notebooks/Experiment2.py
+++ b/book/marimo/notebooks/Experiment2.py
@@ -21,26 +21,14 @@ __generated_with = "0.23.1"
 app = marimo.App()
 
 with app.setup:
+    import sys
     from pathlib import Path
 
-    import marimo as mo
-    import plotly.io as pio
-    import polars as pl
+    sys.path.insert(0, str(Path(__file__).parent))
 
-    from jquantstats import Portfolio, interpolate
+    from preamble import Portfolio, interpolate, load_prices, mo, pio, pl
 
-    # Ensure Plotly works with Marimo
-    pio.renderers.default = "plotly_mimetype"
-
-    path = Path(__file__).parent / "public" / "Prices_hashed.csv"
-
-    date_col = "date"
-
-    dframe = pl.read_csv(str(path), try_parse_dates=True)
-
-    dframe = dframe.with_columns(pl.col(date_col).cast(pl.Datetime("ns")))
-    dframe = dframe.with_columns([pl.col(col).cast(pl.Float64) for col in dframe.columns if col != date_col])
-    prices = interpolate(dframe)
+    prices = load_prices(__file__)
 
 
 @app.cell(hide_code=True)

--- a/book/marimo/notebooks/Experiment2.py
+++ b/book/marimo/notebooks/Experiment2.py
@@ -24,9 +24,13 @@ with app.setup:
     import sys
     from pathlib import Path
 
+    import marimo as mo
+    import polars as pl
+    from jquantstats import Portfolio
+
     sys.path.insert(0, str(Path(__file__).parent))
 
-    from preamble import Portfolio, interpolate, load_prices, mo, pio, pl
+    from preamble import date_col, load_prices
 
     prices = load_prices(__file__)
 

--- a/book/marimo/notebooks/Experiment3.py
+++ b/book/marimo/notebooks/Experiment3.py
@@ -23,28 +23,16 @@ __generated_with = "0.23.1"
 app = marimo.App()
 
 with app.setup:
+    import sys
     from pathlib import Path
 
-    import marimo as mo
-    import plotly.io as pio
-    import polars as pl
+    sys.path.insert(0, str(Path(__file__).parent))
 
-    from jquantstats import Portfolio, interpolate
+    from preamble import Portfolio, interpolate, load_prices, mo, pio, pl
     from tinycta.osc import osc
     from tinycta.util import vol_adj
 
-    # Ensure Plotly works with Marimo
-    pio.renderers.default = "plotly_mimetype"
-
-    path = Path(__file__).parent / "public" / "Prices_hashed.csv"
-
-    date_col = "date"
-
-    dframe = pl.read_csv(str(path), try_parse_dates=True)
-
-    dframe = dframe.with_columns(pl.col(date_col).cast(pl.Datetime("ns")))
-    dframe = dframe.with_columns([pl.col(col).cast(pl.Float64) for col in dframe.columns if col != date_col])
-    prices = interpolate(dframe)
+    prices = load_prices(__file__)
 
 
 @app.cell(hide_code=True)

--- a/book/marimo/notebooks/Experiment3.py
+++ b/book/marimo/notebooks/Experiment3.py
@@ -26,11 +26,15 @@ with app.setup:
     import sys
     from pathlib import Path
 
-    sys.path.insert(0, str(Path(__file__).parent))
-
-    from preamble import Portfolio, interpolate, load_prices, mo, pio, pl
+    import marimo as mo
+    import polars as pl
+    from jquantstats import Portfolio
     from tinycta.osc import osc
     from tinycta.util import vol_adj
+
+    sys.path.insert(0, str(Path(__file__).parent))
+
+    from preamble import date_col, load_prices
 
     prices = load_prices(__file__)
 

--- a/book/marimo/notebooks/Experiment4.py
+++ b/book/marimo/notebooks/Experiment4.py
@@ -26,13 +26,16 @@ with app.setup:
     import sys
     from pathlib import Path
 
-    sys.path.insert(0, str(Path(__file__).parent))
-
+    import marimo as mo
     import numpy as np
-
-    from preamble import Portfolio, interpolate, load_prices, mo, pio, pl
+    import polars as pl
+    from jquantstats import Portfolio
     from tinycta.osc import osc
     from tinycta.util import vol_adj
+
+    sys.path.insert(0, str(Path(__file__).parent))
+
+    from preamble import date_col, load_prices
 
     prices = load_prices(__file__)
 

--- a/book/marimo/notebooks/Experiment4.py
+++ b/book/marimo/notebooks/Experiment4.py
@@ -23,29 +23,18 @@ __generated_with = "0.23.1"
 app = marimo.App()
 
 with app.setup:
+    import sys
     from pathlib import Path
 
-    import marimo as mo
-    import numpy as np
-    import plotly.io as pio
-    import polars as pl
+    sys.path.insert(0, str(Path(__file__).parent))
 
-    from jquantstats import Portfolio, interpolate
+    import numpy as np
+
+    from preamble import Portfolio, interpolate, load_prices, mo, pio, pl
     from tinycta.osc import osc
     from tinycta.util import vol_adj
 
-    # Ensure Plotly works with Marimo
-    pio.renderers.default = "plotly_mimetype"
-
-    path = Path(__file__).parent / "public" / "Prices_hashed.csv"
-
-    date_col = "date"
-
-    dframe = pl.read_csv(str(path), try_parse_dates=True)
-
-    dframe = dframe.with_columns(pl.col(date_col).cast(pl.Datetime("ns")))
-    dframe = dframe.with_columns([pl.col(col).cast(pl.Float64) for col in dframe.columns if col != date_col])
-    prices = interpolate(dframe)
+    prices = load_prices(__file__)
 
 
 @app.cell(hide_code=True)

--- a/book/marimo/notebooks/Experiment5.py
+++ b/book/marimo/notebooks/Experiment5.py
@@ -26,15 +26,18 @@ with app.setup:
     import sys
     from pathlib import Path
 
-    sys.path.insert(0, str(Path(__file__).parent))
-
+    import marimo as mo
     import numpy as np
-
-    from preamble import Portfolio, interpolate, load_prices, mo, pio, pl
+    import polars as pl
+    from jquantstats import Portfolio
     from tinycta.linalg import inv_a_norm, solve
     from tinycta.osc import osc
     from tinycta.signal import shrink2id
     from tinycta.util import vol_adj
+
+    sys.path.insert(0, str(Path(__file__).parent))
+
+    from preamble import date_col, load_prices
 
     prices = load_prices(__file__)
 

--- a/book/marimo/notebooks/Experiment5.py
+++ b/book/marimo/notebooks/Experiment5.py
@@ -23,31 +23,20 @@ __generated_with = "0.23.1"
 app = marimo.App()
 
 with app.setup:
+    import sys
     from pathlib import Path
 
-    import marimo as mo
-    import numpy as np
-    import plotly.io as pio
-    import polars as pl
+    sys.path.insert(0, str(Path(__file__).parent))
 
-    from jquantstats import Portfolio, interpolate
+    import numpy as np
+
+    from preamble import Portfolio, interpolate, load_prices, mo, pio, pl
     from tinycta.linalg import inv_a_norm, solve
     from tinycta.osc import osc
     from tinycta.signal import shrink2id
     from tinycta.util import vol_adj
 
-    # Ensure Plotly works with Marimo
-    pio.renderers.default = "plotly_mimetype"
-
-    path = Path(__file__).parent / "public" / "Prices_hashed.csv"
-
-    date_col = "date"
-
-    dframe = pl.read_csv(str(path), try_parse_dates=True)
-
-    dframe = dframe.with_columns(pl.col(date_col).cast(pl.Datetime("ns")))
-    dframe = dframe.with_columns([pl.col(col).cast(pl.Float64) for col in dframe.columns if col != date_col])
-    prices = interpolate(dframe)
+    prices = load_prices(__file__)
 
 
 @app.cell(hide_code=True)

--- a/book/marimo/notebooks/preamble.py
+++ b/book/marimo/notebooks/preamble.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+import marimo as mo
+import plotly.io as pio
+import polars as pl
+
+pio.renderers.default = "plotly_mimetype"
+
+
+def load_prices(notebook_file: str) -> pl.DataFrame:
+    date_col = "date"
+    path = Path(notebook_file).parent / "public" / "Prices_hashed.csv"
+    dframe = pl.read_csv(str(path), try_parse_dates=True)
+    dframe = dframe.with_columns(pl.col(date_col).cast(pl.Datetime("ns")))
+    dframe = dframe.with_columns([pl.col(col).cast(pl.Float64) for col in dframe.columns if col != date_col])
+    return interpolate(dframe)

--- a/book/marimo/notebooks/preamble.py
+++ b/book/marimo/notebooks/preamble.py
@@ -1,14 +1,18 @@
+"""Shared data loading for marimo experiment notebooks."""
+
 from pathlib import Path
 
-import marimo as mo
 import plotly.io as pio
 import polars as pl
+from jquantstats import interpolate
 
 pio.renderers.default = "plotly_mimetype"
 
+date_col = "date"
+
 
 def load_prices(notebook_file: str) -> pl.DataFrame:
-    date_col = "date"
+    """Load and preprocess prices from the standard CSV file."""
     path = Path(notebook_file).parent / "public" / "Prices_hashed.csv"
     dframe = pl.read_csv(str(path), try_parse_dates=True)
     dframe = dframe.with_columns(pl.col(date_col).cast(pl.Datetime("ns")))


### PR DESCRIPTION
## Summary

- Creates `book/marimo/notebooks/preamble.py` to hold the repeated data-loading setup shared by all five experiment notebooks
- Exports `date_col` (module-level constant) and `load_prices(notebook_file)` (handles CSV reading, casting, and interpolation)
- Sets the Plotly renderer as a side-effect on import, so notebooks no longer need to do it themselves
- Each `app.setup` block imports its own `mo`, `pl`, `Portfolio`, etc. directly; only `date_col` and `load_prices` come from preamble

## Test plan

- [ ] Run each experiment notebook (`marimo run Experiment{1..5}.py`) and confirm prices load correctly
- [ ] Confirm `date_col` is available in cells that reference it (Experiments 1–5)
- [ ] `uvx ruff check book/marimo/notebooks/` passes with no new errors introduced by this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)