### PR TITLE
fix(notebooks): use profit/AUM returns for Sharpe ratio computation

### DIFF
--- a/book/marimo/notebooks/Experiment1.py
+++ b/book/marimo/notebooks/Experiment1.py
@@ -66,8 +66,8 @@ def _(fast, slow):
 
 @app.cell
 def _(portfolio):
-    _nav = portfolio.nav_accumulated["NAV_accumulated"].pct_change().drop_nulls()
-    print(float(_nav.mean() / _nav.std(ddof=1) * portfolio.data._periods_per_year**0.5))
+    _r = portfolio.returns["returns"]
+    print(float(_r.mean() / _r.std(ddof=1) * portfolio.data._periods_per_year**0.5))
 
 
 @app.cell(hide_code=True)

--- a/book/marimo/notebooks/Experiment2.py
+++ b/book/marimo/notebooks/Experiment2.py
@@ -70,8 +70,8 @@ def _(fast, slow, vola):
 
 @app.cell
 def _(portfolio):
-    _nav = portfolio.nav_accumulated["NAV_accumulated"].pct_change().drop_nulls()
-    print(float(_nav.mean() / _nav.std(ddof=1) * portfolio.data._periods_per_year**0.5))
+    _r = portfolio.returns["returns"]
+    print(float(_r.mean() / _r.std(ddof=1) * portfolio.data._periods_per_year**0.5))
 
 
 @app.cell(hide_code=True)

--- a/book/marimo/notebooks/Experiment3.py
+++ b/book/marimo/notebooks/Experiment3.py
@@ -122,8 +122,8 @@ def _(fast, slow, vola, winsor):
 
 @app.cell
 def _(portfolio):
-    _nav = portfolio.nav_accumulated["NAV_accumulated"].pct_change().drop_nulls()
-    print(float(_nav.mean() / _nav.std(ddof=1) * portfolio.data._periods_per_year**0.5))
+    _r = portfolio.returns["returns"]
+    print(float(_r.mean() / _r.std(ddof=1) * portfolio.data._periods_per_year**0.5))
 
 
 @app.cell

--- a/book/marimo/notebooks/Experiment4.py
+++ b/book/marimo/notebooks/Experiment4.py
@@ -87,8 +87,8 @@ def _(fast, slow, vola, winsor):
 
 @app.cell
 def _(portfolio):
-    _nav = portfolio.nav_accumulated["NAV_accumulated"].pct_change().drop_nulls()
-    print(float(_nav.mean() / _nav.std(ddof=1) * portfolio.data._periods_per_year**0.5))
+    _r = portfolio.returns["returns"]
+    print(float(_r.mean() / _r.std(ddof=1) * portfolio.data._periods_per_year**0.5))
 
 
 @app.cell

--- a/book/marimo/notebooks/Experiment5.py
+++ b/book/marimo/notebooks/Experiment5.py
@@ -139,8 +139,8 @@ def _(corr, shrinkage, vola, winsor):
 
 @app.cell
 def _(portfolio):
-    _nav = portfolio.nav_accumulated["NAV_accumulated"].pct_change().drop_nulls()
-    print(float(_nav.mean() / _nav.std(ddof=1) * portfolio.data._periods_per_year**0.5))
+    _r = portfolio.returns["returns"]
+    print(float(_r.mean() / _r.std(ddof=1) * portfolio.data._periods_per_year**0.5))
 
 
 @app.cell(hide_code=True)

--- a/tests/test_notebook_sharpe.py
+++ b/tests/test_notebook_sharpe.py
@@ -16,11 +16,11 @@ NOTEBOOK_DIR = (ROOT / "book" / "marimo" / "notebooks").resolve()
 FLOAT_PATTERN = re.compile(r"[-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?")
 NOTEBOOKS = sorted(path.resolve() for path in NOTEBOOK_DIR.glob("Experiment*.py"))
 EXPECTED_SHARPE_RATIOS = {
-    "Experiment1": 0.7819474087813011,
-    "Experiment2": 1.1260755020625202,
-    "Experiment3": 1.1285498216316372,
-    "Experiment4": 1.140873971788052,
-    "Experiment5": 1.393306947248026,
+    "Experiment1": 0.5605552118857117,
+    "Experiment2": 0.8793799321235558,
+    "Experiment3": 0.8776423555933839,
+    "Experiment4": 1.0712152818814276,
+    "Experiment5": 1.4652366037605955,
 }
 SHARPE_RATIO_REL_TOLERANCE = 1e-6
 SHARPE_RATIO_ABS_TOLERANCE = 1e-6


### PR DESCRIPTION
## Summary

- Replaces `pct_change(NAV_accumulated)` with `portfolio.returns["returns"]` for the Sharpe ratio computation in all five experiment notebooks
- `NAV_accumulated` uses a time-varying denominator (current NAV), while `portfolio.returns` divides profit by the fixed initial AUM — consistent with the jquantstats convention
- Updates test baselines to match the new values

## Why it matters

For a profitable strategy, NAV grows above AUM, making `profit/NAV < profit/AUM`. The old computation was silently inflating the Sharpe ratio relative to what the library reports internally. The new values are uniformly lower for strategies 1–4 and slightly higher for strategy 5.

## Test plan

- [x] `make test` passes locally (6/6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated performance metric baseline expectations for experiment notebooks to reflect revised calculation methodology.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tschm/cs/pull/398?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->