### PR TITLE
test: add test suites for preamble and experiments 2–5

### DIFF
--- a/.github/workflows/rhiza_ci.yml
+++ b/.github/workflows/rhiza_ci.yml
@@ -1,0 +1,58 @@
+# This file is part of the jebel-quant/rhiza repository
+# (https://github.com/jebel-quant/rhiza).
+#
+# Workflow: CI
+#
+# Purpose: Runs the test suite across all supported Python versions and
+#          operating systems to surface compatibility issues early.
+#
+# Trigger: This workflow runs on every push and on pull requests to main/master
+#          branches (including from forks)
+
+name: "(RHIZA) CI"
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+
+jobs:
+  test:
+    name: "Python ${{ matrix.python-version }} / ${{ matrix.os }}"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
+
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          version: "0.11.7"
+          python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
+
+      - name: Configure git auth for private packages
+        uses: ./.github/actions/configure-git-auth
+        with:
+          token: ${{ secrets.GH_PAT }}
+
+      - name: Install dependencies
+        env:
+          UV_EXTRA_INDEX_URL: ${{ secrets.UV_EXTRA_INDEX_URL }}
+          UV_INDEX_STRATEGY: unsafe-best-match
+        run: uv sync --group dev
+
+      - name: Run tests
+        env:
+          UV_EXTRA_INDEX_URL: ${{ secrets.UV_EXTRA_INDEX_URL }}
+          UV_INDEX_STRATEGY: unsafe-best-match
+        run: uv run pytest tests/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "cs"
 version = "1.0.0"
 description = "Companion materials for the Computational Statistics project."
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = ">=3.11"
 authors = [{ name = "Thomas Schmelzer" }]
 license = { file = "LICENSE" }
 dependencies = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,16 @@
+"""Shared pytest fixtures for experiment signal function tests."""
+
+import polars as pl
+import pytest
+
+N = 600  # satisfies min_samples=300 (the highest requirement across all experiments)
+
+
+@pytest.fixture
+def rising():
+    return pl.DataFrame({"p": [float(i) for i in range(1, N + 1)]})
+
+
+@pytest.fixture
+def falling():
+    return pl.DataFrame({"p": [float(i) for i in range(N, 0, -1)]})

--- a/tests/test_experiment2.py
+++ b/tests/test_experiment2.py
@@ -1,4 +1,4 @@
-"""Tests for the signal function f defined in Experiment 1."""
+"""Tests for the signal function f defined in Experiment 2."""
 
 import runpy
 from pathlib import Path
@@ -8,27 +8,22 @@ import polars as pl
 ROOT = Path(__file__).resolve().parents[1]
 NOTEBOOK_DIR = ROOT / "book" / "marimo" / "notebooks"
 
-f = runpy.run_path(str(NOTEBOOK_DIR / "Experiment1.py"))["f"]
-
-
-def test_f_signal_values_are_sign(rising):
-    result = rising.select(f(pl.col("p")).drop_nulls())
-    assert result["p"].is_in([-1.0, 0.0, 1.0]).all()
+f = runpy.run_path(str(NOTEBOOK_DIR / "Experiment2.py"))["f"]
 
 
 def test_f_rising_trend_gives_positive_signal(rising):
     result = rising.select(f(pl.col("p")).drop_nulls())
-    assert (result["p"] == 1.0).all()
+    assert (result["p"] > 0).all()
 
 
 def test_f_falling_trend_gives_negative_signal(falling):
     result = falling.select(f(pl.col("p")).drop_nulls())
-    assert (result["p"] == -1.0).all()
+    assert (result["p"] < 0).all()
 
 
 def test_f_nulls_before_min_samples(rising):
     result = rising.select(f(pl.col("p")))
-    assert result["p"].null_count() >= 99
+    assert result["p"].null_count() >= 299
 
 
 def test_f_default_fast_is_32(rising):
@@ -43,9 +38,14 @@ def test_f_default_slow_is_96(rising):
     assert default.equals(explicit)
 
 
+def test_f_default_volatility_is_32(rising):
+    default = rising.select(f(pl.col("p")).drop_nulls())
+    explicit = rising.select(f(pl.col("p"), volatility=32).drop_nulls())
+    assert default.equals(explicit)
+
+
 def test_f_different_params_give_different_results():
-    # Up then down: fast params detect the reversal sooner than slow params.
-    prices = pl.DataFrame({"p": [float(i) for i in range(1, 301)] + [float(i) for i in range(300, 0, -1)]})
-    slow_signal = prices.select(f(pl.col("p")).drop_nulls())
+    prices = pl.DataFrame({"p": [float(i) for i in range(1, 601)] + [float(i) for i in range(600, 0, -1)]})
+    default_signal = prices.select(f(pl.col("p")).drop_nulls())
     fast_signal = prices.select(f(pl.col("p"), fast=4, slow=8).drop_nulls())
-    assert not slow_signal.equals(fast_signal)
+    assert not default_signal.equals(fast_signal)

--- a/tests/test_experiment3.py
+++ b/tests/test_experiment3.py
@@ -1,0 +1,57 @@
+"""Tests for the signal function f defined in Experiment 3."""
+
+import runpy
+from pathlib import Path
+
+import polars as pl
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTEBOOK_DIR = ROOT / "book" / "marimo" / "notebooks"
+
+f = runpy.run_path(str(NOTEBOOK_DIR / "Experiment3.py"))["f"]
+
+
+def test_f_rising_trend_gives_positive_signal(rising):
+    result = rising.select(f(pl.col("p")).drop_nulls())
+    assert (result["p"] >= 0).all()
+
+
+def test_f_falling_trend_gives_negative_signal(falling):
+    result = falling.select(f(pl.col("p")).drop_nulls())
+    assert (result["p"] <= 0).all()
+
+
+def test_f_nulls_before_min_samples(rising):
+    result = rising.select(f(pl.col("p")))
+    assert result["p"].null_count() >= 299
+
+
+def test_f_default_slow_is_96(rising):
+    default = rising.select(f(pl.col("p")).drop_nulls())
+    explicit = rising.select(f(pl.col("p"), slow=96).drop_nulls())
+    assert default.equals(explicit)
+
+
+def test_f_default_fast_is_32(rising):
+    default = rising.select(f(pl.col("p")).drop_nulls())
+    explicit = rising.select(f(pl.col("p"), fast=32).drop_nulls())
+    assert default.equals(explicit)
+
+
+def test_f_default_vola_is_96(rising):
+    default = rising.select(f(pl.col("p")).drop_nulls())
+    explicit = rising.select(f(pl.col("p"), vola=96).drop_nulls())
+    assert default.equals(explicit)
+
+
+def test_f_default_clip_is_3(rising):
+    default = rising.select(f(pl.col("p")).drop_nulls())
+    explicit = rising.select(f(pl.col("p"), clip=3).drop_nulls())
+    assert default.equals(explicit)
+
+
+def test_f_different_params_give_different_results():
+    prices = pl.DataFrame({"p": [float(i) for i in range(1, 601)] + [float(i) for i in range(600, 0, -1)]})
+    default_signal = prices.select(f(pl.col("p")).drop_nulls())
+    fast_signal = prices.select(f(pl.col("p"), fast=4, slow=8).drop_nulls())
+    assert not default_signal.equals(fast_signal)

--- a/tests/test_experiment4.py
+++ b/tests/test_experiment4.py
@@ -1,4 +1,4 @@
-"""Tests for the signal function f defined in Experiment 1."""
+"""Tests for the signal function f defined in Experiment 4."""
 
 import runpy
 from pathlib import Path
@@ -8,27 +8,28 @@ import polars as pl
 ROOT = Path(__file__).resolve().parents[1]
 NOTEBOOK_DIR = ROOT / "book" / "marimo" / "notebooks"
 
-f = runpy.run_path(str(NOTEBOOK_DIR / "Experiment1.py"))["f"]
+f = runpy.run_path(str(NOTEBOOK_DIR / "Experiment4.py"))["f"]
 
 
-def test_f_signal_values_are_sign(rising):
+def test_f_signal_is_bounded_by_tanh(rising):
     result = rising.select(f(pl.col("p")).drop_nulls())
-    assert result["p"].is_in([-1.0, 0.0, 1.0]).all()
+    assert (result["p"] >= -1).all()
+    assert (result["p"] <= 1).all()
 
 
 def test_f_rising_trend_gives_positive_signal(rising):
     result = rising.select(f(pl.col("p")).drop_nulls())
-    assert (result["p"] == 1.0).all()
+    assert (result["p"] >= 0).all()
 
 
 def test_f_falling_trend_gives_negative_signal(falling):
     result = falling.select(f(pl.col("p")).drop_nulls())
-    assert (result["p"] == -1.0).all()
+    assert (result["p"] <= 0).all()
 
 
 def test_f_nulls_before_min_samples(rising):
     result = rising.select(f(pl.col("p")))
-    assert result["p"].null_count() >= 99
+    assert result["p"].null_count() >= 299
 
 
 def test_f_default_fast_is_32(rising):
@@ -43,9 +44,20 @@ def test_f_default_slow_is_96(rising):
     assert default.equals(explicit)
 
 
+def test_f_default_vola_is_32(rising):
+    default = rising.select(f(pl.col("p")).drop_nulls())
+    explicit = rising.select(f(pl.col("p"), vola=32).drop_nulls())
+    assert default.equals(explicit)
+
+
+def test_f_default_clip_is_4_2(rising):
+    default = rising.select(f(pl.col("p")).drop_nulls())
+    explicit = rising.select(f(pl.col("p"), clip=4.2).drop_nulls())
+    assert default.equals(explicit)
+
+
 def test_f_different_params_give_different_results():
-    # Up then down: fast params detect the reversal sooner than slow params.
-    prices = pl.DataFrame({"p": [float(i) for i in range(1, 301)] + [float(i) for i in range(300, 0, -1)]})
-    slow_signal = prices.select(f(pl.col("p")).drop_nulls())
+    prices = pl.DataFrame({"p": [float(i) for i in range(1, 601)] + [float(i) for i in range(600, 0, -1)]})
+    default_signal = prices.select(f(pl.col("p")).drop_nulls())
     fast_signal = prices.select(f(pl.col("p"), fast=4, slow=8).drop_nulls())
-    assert not slow_signal.equals(fast_signal)
+    assert not default_signal.equals(fast_signal)

--- a/tests/test_experiment5.py
+++ b/tests/test_experiment5.py
@@ -1,4 +1,4 @@
-"""Tests for the signal function f defined in Experiment 1."""
+"""Tests for the signal function f defined in Experiment 5."""
 
 import runpy
 from pathlib import Path
@@ -8,27 +8,28 @@ import polars as pl
 ROOT = Path(__file__).resolve().parents[1]
 NOTEBOOK_DIR = ROOT / "book" / "marimo" / "notebooks"
 
-f = runpy.run_path(str(NOTEBOOK_DIR / "Experiment1.py"))["f"]
+f = runpy.run_path(str(NOTEBOOK_DIR / "Experiment5.py"))["f"]
 
 
-def test_f_signal_values_are_sign(rising):
+def test_f_signal_is_bounded_by_tanh(rising):
     result = rising.select(f(pl.col("p")).drop_nulls())
-    assert result["p"].is_in([-1.0, 0.0, 1.0]).all()
+    assert (result["p"] >= -1).all()
+    assert (result["p"] <= 1).all()
 
 
 def test_f_rising_trend_gives_positive_signal(rising):
     result = rising.select(f(pl.col("p")).drop_nulls())
-    assert (result["p"] == 1.0).all()
+    assert (result["p"] >= 0).all()
 
 
 def test_f_falling_trend_gives_negative_signal(falling):
     result = falling.select(f(pl.col("p")).drop_nulls())
-    assert (result["p"] == -1.0).all()
+    assert (result["p"] <= 0).all()
 
 
 def test_f_nulls_before_min_samples(rising):
     result = rising.select(f(pl.col("p")))
-    assert result["p"].null_count() >= 99
+    assert result["p"].null_count() >= 299
 
 
 def test_f_default_fast_is_32(rising):
@@ -43,9 +44,20 @@ def test_f_default_slow_is_96(rising):
     assert default.equals(explicit)
 
 
+def test_f_default_vola_is_32(rising):
+    default = rising.select(f(pl.col("p")).drop_nulls())
+    explicit = rising.select(f(pl.col("p"), vola=32).drop_nulls())
+    assert default.equals(explicit)
+
+
+def test_f_default_clip_is_4_2(rising):
+    default = rising.select(f(pl.col("p")).drop_nulls())
+    explicit = rising.select(f(pl.col("p"), clip=4.2).drop_nulls())
+    assert default.equals(explicit)
+
+
 def test_f_different_params_give_different_results():
-    # Up then down: fast params detect the reversal sooner than slow params.
-    prices = pl.DataFrame({"p": [float(i) for i in range(1, 301)] + [float(i) for i in range(300, 0, -1)]})
-    slow_signal = prices.select(f(pl.col("p")).drop_nulls())
+    prices = pl.DataFrame({"p": [float(i) for i in range(1, 601)] + [float(i) for i in range(600, 0, -1)]})
+    default_signal = prices.select(f(pl.col("p")).drop_nulls())
     fast_signal = prices.select(f(pl.col("p"), fast=4, slow=8).drop_nulls())
-    assert not slow_signal.equals(fast_signal)
+    assert not default_signal.equals(fast_signal)

--- a/tests/test_preamble.py
+++ b/tests/test_preamble.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import plotly.io as pio
 import polars as pl
+import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 NOTEBOOK_DIR = ROOT / "book" / "marimo" / "notebooks"
@@ -15,6 +16,11 @@ load_prices = preamble["load_prices"]
 date_col = preamble["date_col"]
 
 
+@pytest.fixture(scope="module")
+def prices_df():
+    return load_prices(NOTEBOOK_FILE)
+
+
 def test_date_col_constant():
     assert date_col == "date"
 
@@ -23,35 +29,30 @@ def test_plotly_renderer_is_set():
     assert pio.renderers.default == "plotly_mimetype"
 
 
-def test_load_prices_returns_dataframe():
-    df = load_prices(NOTEBOOK_FILE)
-    assert isinstance(df, pl.DataFrame)
+def test_load_prices_returns_dataframe(prices_df):
+    assert isinstance(prices_df, pl.DataFrame)
 
 
-def test_load_prices_not_empty():
-    df = load_prices(NOTEBOOK_FILE)
-    assert df.height > 0
-    assert df.width > 0
+def test_load_prices_not_empty(prices_df):
+    assert prices_df.height > 0
+    assert prices_df.width > 0
 
 
-def test_load_prices_has_date_column():
-    df = load_prices(NOTEBOOK_FILE)
-    assert date_col in df.columns
+def test_load_prices_has_date_column(prices_df):
+    assert date_col in prices_df.columns
 
 
-def test_load_prices_date_column_dtype():
-    df = load_prices(NOTEBOOK_FILE)
-    assert df[date_col].dtype == pl.Datetime("ns")
+def test_load_prices_date_column_dtype(prices_df):
+    assert prices_df[date_col].dtype == pl.Datetime("ns")
 
 
-def test_load_prices_non_date_columns_are_float64():
-    df = load_prices(NOTEBOOK_FILE)
-    for col in df.columns:
+def test_load_prices_non_date_columns_are_float64(prices_df):
+    for col in prices_df.columns:
         if col != date_col:
-            assert df[col].dtype == pl.Float64, f"Column {col!r} is not Float64"
+            assert prices_df[col].dtype == pl.Float64, f"Column {col!r} is not Float64"
 
 
-def test_load_prices_interpolation_applied():
+def test_load_prices_interpolation_applied(prices_df):
     from jquantstats import interpolate
 
     path = Path(NOTEBOOK_FILE).parent / "public" / "Prices_hashed.csv"
@@ -59,4 +60,4 @@ def test_load_prices_interpolation_applied():
     raw = raw.with_columns(pl.col(date_col).cast(pl.Datetime("ns")))
     raw = raw.with_columns([pl.col(col).cast(pl.Float64) for col in raw.columns if col != date_col])
 
-    assert load_prices(NOTEBOOK_FILE).equals(interpolate(raw))
+    assert prices_df.equals(interpolate(raw))

--- a/tests/test_preamble.py
+++ b/tests/test_preamble.py
@@ -1,0 +1,62 @@
+"""Tests for the preamble module shared by marimo experiment notebooks."""
+
+import runpy
+from pathlib import Path
+
+import plotly.io as pio
+import polars as pl
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTEBOOK_DIR = ROOT / "book" / "marimo" / "notebooks"
+NOTEBOOK_FILE = str(NOTEBOOK_DIR / "Experiment1.py")
+
+preamble = runpy.run_path(str(NOTEBOOK_DIR / "preamble.py"))
+load_prices = preamble["load_prices"]
+date_col = preamble["date_col"]
+
+
+def test_date_col_constant():
+    assert date_col == "date"
+
+
+def test_plotly_renderer_is_set():
+    assert pio.renderers.default == "plotly_mimetype"
+
+
+def test_load_prices_returns_dataframe():
+    df = load_prices(NOTEBOOK_FILE)
+    assert isinstance(df, pl.DataFrame)
+
+
+def test_load_prices_not_empty():
+    df = load_prices(NOTEBOOK_FILE)
+    assert df.height > 0
+    assert df.width > 0
+
+
+def test_load_prices_has_date_column():
+    df = load_prices(NOTEBOOK_FILE)
+    assert date_col in df.columns
+
+
+def test_load_prices_date_column_dtype():
+    df = load_prices(NOTEBOOK_FILE)
+    assert df[date_col].dtype == pl.Datetime("ns")
+
+
+def test_load_prices_non_date_columns_are_float64():
+    df = load_prices(NOTEBOOK_FILE)
+    for col in df.columns:
+        if col != date_col:
+            assert df[col].dtype == pl.Float64, f"Column {col!r} is not Float64"
+
+
+def test_load_prices_interpolation_applied():
+    from jquantstats import interpolate
+
+    path = Path(NOTEBOOK_FILE).parent / "public" / "Prices_hashed.csv"
+    raw = pl.read_csv(str(path), try_parse_dates=True)
+    raw = raw.with_columns(pl.col(date_col).cast(pl.Datetime("ns")))
+    raw = raw.with_columns([pl.col(col).cast(pl.Float64) for col in raw.columns if col != date_col])
+
+    assert load_prices(NOTEBOOK_FILE).equals(interpolate(raw))


### PR DESCRIPTION
## Summary

- Adds `tests/test_preamble.py` covering `load_prices` dtype casting, interpolation, and module-level side effects
- Adds `tests/test_experiment{2,3,4,5}.py` covering signal direction, null warmup period, default parameters, and parameter sensitivity for each experiment's `f` function
- Extracts shared `rising`/`falling` fixtures (N=600) into `tests/conftest.py`, removing duplication across all test files
- Updates `test_experiment1.py` to use the shared fixtures from `conftest.py`

## Test plan

- [ ] All 48 tests pass: `uv run pytest tests/test_preamble.py tests/test_experiment1.py tests/test_experiment2.py tests/test_experiment3.py tests/test_experiment4.py tests/test_experiment5.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured automated testing across Python 3.11–3.14 on Ubuntu, macOS, and Windows
  * Lowered minimum Python version requirement to 3.11

* **Tests**
  * Added shared test fixtures for common test data
  * Introduced comprehensive test suites for signal functions and data loading utilities

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tschm/cs/pull/400?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->