### PR TITLE
Guide Windows users to a POSIX shell for make targets

### DIFF
--- a/.rhiza/rhiza.mk
+++ b/.rhiza/rhiza.mk
@@ -10,6 +10,37 @@ ifndef MAKE_VERSION
 $(error GNU Make is required. macOS ships BSD make — install GNU Make with: brew install make)
 endif
 
+# Require a working POSIX shell.
+# Recipes use POSIX shell syntax (mkdir -p, printf, [ ... ], curl | sh). GNU Make
+# runs recipes with sh when it finds one on PATH -- even when make itself was
+# launched from PowerShell or cmd -- so e.g. CI on windows-latest (which ships
+# Git's sh.exe) works fine. Only when no POSIX shell is found does make fall back
+# to cmd.exe, where the recipes fail on the first non-cmd line with errors like:
+#   process_begin: CreateProcess(NULL, # Ensure ... folder exists, ...) failed.
+# So probe the shell make actually uses rather than guessing from the OS: run a
+# POSIX command and require its output. Guarded by $(OS) so the probe only runs
+# on Windows (no subprocess cost on Linux/macOS/WSL, where the shell is POSIX).
+ifeq ($(OS),Windows_NT)
+ifneq ($(shell printf POSIX),POSIX)
+define RHIZA_WINDOWS_SHELL_ERROR
+
+  This project's Makefile requires a POSIX shell, but make could not find one
+  and fell back to cmd.exe, which is not supported.
+
+  Run 'make' from an environment that provides a POSIX shell, e.g.:
+    - WSL (recommended):  https://learn.microsoft.com/windows/wsl/install
+    - Git Bash:           bundled with Git for Windows (https://git-scm.com/download/win)
+
+  Tip: if 'sh.exe' (from Git for Windows) is on your PATH, make will use it
+  automatically even from PowerShell or cmd.
+
+  See README.md > Prerequisites for details.
+
+endef
+$(error $(RHIZA_WINDOWS_SHELL_ERROR))
+endif
+endif
+
 # Colours for pretty output in help messages
 BLUE := \033[36m
 BOLD := \033[1m

--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ opens the door to deeper insights into the strategy.
 ### 📋 Prerequisites
 
 - Python 3.12+
+- A POSIX shell. macOS and Linux have one by default.
+
+> **🪟 Windows users:** The `make` targets are written for a POSIX shell and
+> rely on tools like `mkdir -p`, `printf`, `curl`, and `[ … ]`. They will **not**
+> run under `cmd.exe` or PowerShell — you'll see errors such as
+> `process_begin: CreateProcess(NULL, # Ensure the … folder exists, …) failed.`
+> Run the commands below from **WSL** (recommended) or **Git Bash**, both of
+> which provide a POSIX shell.
 
 ### 🔧 Installation
 


### PR DESCRIPTION
## Problem

A Windows user running `make book` hit a cryptic error:

```
process_begin: CreateProcess(NULL, # Ensure the C:/cs/bin folder exists, ...) failed.
```

The `make` recipes use POSIX shell syntax throughout (`mkdir -p`, `printf`, `[ ... ]`, `curl | sh`). When `make` can't find a POSIX shell and falls back to `cmd.exe`, it fails on the first non-cmd line — here, a `#` recipe-comment that `sh` treats as a comment but `cmd.exe` treats as a bogus command name.

## Change

- **README** — add a Prerequisites note telling Windows users to run `make` from **WSL** or **Git Bash**, and showing the exact error so anyone who hits it lands on the fix.
- **`.rhiza/rhiza.mk`** — add an early guard (next to the existing GNU Make check) that probes the shell make actually uses and aborts with a clear message instead of the `CreateProcess` error, **only** when make has fallen back to `cmd.exe`:

  ```make
  ifeq ($(OS),Windows_NT)
  ifneq ($(shell printf POSIX),POSIX)
  $(error <helpful message>)
  endif
  endif
  ```

  It stays silent wherever a POSIX shell is in use (Git Bash, WSL, macOS, Linux, and the `sh`-on-PATH case CI relies on), and spawns no subprocess off Windows.

## Note on `.rhiza/`

`.rhiza/rhiza.mk` is template-managed (synced from `jebel-quant/rhiza`). The same guard is in [jebel-quant/rhiza#1146](https://github.com/Jebel-Quant/rhiza/pull/1146); this local copy will converge with upstream on the next `make sync` (content already matches, so no conflict). The README change lives in this repo permanently.

## Verification

- `make help` runs normally on macOS (guard is a no-op).
- Probe returns `POSIX` through a POSIX shell → no error; empty under cmd.exe fallback → prints guidance and stops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated prerequisites section to clarify POSIX shell requirements and provide Windows users with setup guidance for WSL or Git Bash

* **Chores**
  * Enhanced build system validation to ensure POSIX shell compatibility and provide helpful error messages for Windows environments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->