### PR TITLE
Add ClusterFuzzLite fuzz suite

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,0 +1,9 @@
+# ClusterFuzzLite build image for cs.
+# Uses the OSS-Fuzz Python base image, which provides Atheris and the
+# compile_python_fuzzer helper. Pinned by SHA256 so the build image only
+# changes through reviewed updates.
+FROM gcr.io/oss-fuzz-base/base-builder-python@sha256:9c97273c8de83d22a40462fdda4371d1ff16eac065c72ee03bef7fdb1aaaf458
+
+COPY . $SRC
+WORKDIR $SRC
+COPY .clusterfuzzlite/build.sh $SRC/build.sh

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -eu
+# ClusterFuzzLite build script — installs the package so the frozen harness can
+# import the project's runtime dependencies, then compiles each Python harness
+# in tests/fuzz/ via OSS-Fuzz's compile_python_fuzzer helper.
+
+cd "$SRC"
+
+# Pin pip so the build environment is reproducible and only changes through a
+# reviewed bump (the same rationale as the SHA-pinned base image).
+pip3 install --upgrade "pip==24.3.1"
+
+# Install the project and its runtime deps (numpy/polars/jquantstats/tinycta)
+# into the build image so PyInstaller can discover and bundle them into each
+# frozen fuzz binary. This repo is not src-layout: the importable signal modules
+# are flat files under book/marimo/notebooks, which the harness puts on sys.path.
+pip3 install .
+
+for fuzzer in tests/fuzz/fuzz_*.py; do
+  compile_python_fuzzer "$fuzzer"
+done

--- a/.clusterfuzzlite/project.yaml
+++ b/.clusterfuzzlite/project.yaml
@@ -1,0 +1,1 @@
+language: python

--- a/tests/fuzz/fuzz_signal.py
+++ b/tests/fuzz/fuzz_signal.py
@@ -1,0 +1,107 @@
+"""Fuzz the CTA experiment signal functions against arbitrary numeric input.
+
+Each ``ExperimentN.py`` marimo notebook exposes a module-level signal function
+``f(price, ...)`` that maps a polars price expression and a handful of numeric
+parameters (``fast``/``slow``/``vola``/``clip``/``volatility``) to a position
+signal expression. These functions are the numeric core of the project: there is
+no string/bytes/config parser surface to fuzz, so this harness synthesizes a
+price series and parameter set from arbitrary bytes and drives every ``f``
+through the same ``DataFrame.select`` evaluation path the notebooks use. It
+asserts each function either evaluates or rejects the input with a documented
+exception (a parameter ``ValueError``/``TypeError`` or a ``polars.PolarsError``
+from the lazy compute layer) — never an unexpected crash.
+
+Run locally:
+    RHIZA_FUZZ_ROOT=$(pwd) pip install atheris
+    RHIZA_FUZZ_ROOT=$(pwd) python tests/fuzz/fuzz_signal.py -atheris_runs=10000
+
+Run in ClusterFuzzLite: this file is built by .clusterfuzzlite/build.sh.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import math
+import os
+import sys
+from pathlib import Path
+
+import atheris
+
+# When running from the source tree (local development), add the marimo notebook
+# directory to sys.path so the ``ExperimentN`` modules (which define ``f``)
+# import without installation. This repo is not src-layout: the importable
+# modules are flat files under book/marimo/notebooks, exactly the directory the
+# project's own tests put on sys.path. In ClusterFuzzLite, build.sh runs
+# `pip install .` to provide the runtime deps (numpy/polars/jquantstats/tinycta)
+# and copies the repo into the frozen binary, so these modules resolve there too.
+_REPO_ROOT = Path(os.environ.get("RHIZA_FUZZ_ROOT", str(Path(__file__).resolve().parent.parent.parent)))
+_NOTEBOOK_DIR = str(_REPO_ROOT / "book" / "marimo" / "notebooks")
+if _NOTEBOOK_DIR not in sys.path:
+    sys.path.insert(0, _NOTEBOOK_DIR)
+
+import Experiment1  # noqa: E402
+import Experiment2  # noqa: E402
+import Experiment3  # noqa: E402
+import Experiment4  # noqa: E402
+import Experiment5  # noqa: E402
+import polars as pl  # noqa: E402
+from polars.exceptions import PolarsError  # noqa: E402
+
+# Documented rejections of malformed input:
+#   * ValueError  — the EWM parameters reject non-positive ``com`` (a negative
+#     fast/slow/vola/volatility), and "one of com/span/half_life/alpha must be
+#     set" when a parameter is None.
+#   * TypeError   — a non-numeric parameter fails the parameter comparisons /
+#     unary-minus inside the polars and tinycta call paths.
+#   * PolarsError — the lazy compute layer (ComputeError, InvalidOperationError,
+#     SchemaError, ShapeError, ...) rejects a degenerate series/expression.
+# Any other exception is a genuine crash and is allowed to propagate.
+_EXPECTED_SIGNAL_ERRORS = (ValueError, TypeError, PolarsError)
+
+# The smallest sensible series; tinycta's vol_adj/osc paths (Experiments 3-5) use
+# min_samples up to 300, so a short series simply yields nulls rather than error.
+_MIN_ROWS = 2
+_MAX_ROWS = 512
+
+
+def test_one_input(data: bytes) -> None:
+    """Build a price series and parameters from bytes, then evaluate each signal ``f``."""
+    fdp = atheris.FuzzedDataProvider(data)
+
+    n_rows = _MIN_ROWS + fdp.ConsumeIntInRange(0, _MAX_ROWS - _MIN_ROWS)
+    prices = [fdp.ConsumeRegularFloat() for _ in range(n_rows)]
+    # A column that is entirely non-finite carries no signal and only exercises
+    # numpy/polars NaN handling, which is not the surface under test; skip it.
+    if not any(math.isfinite(value) for value in prices):
+        return
+    frame = pl.DataFrame({"p": prices})
+
+    # Parameters span the notebook slider ranges and then some, including the
+    # adversarial out-of-range / degenerate values the documented exceptions cover.
+    fast = fdp.ConsumeIntInRange(-8, 256)
+    slow = fdp.ConsumeIntInRange(-8, 256)
+    vola = fdp.ConsumeIntInRange(-8, 256)
+    volatility = fdp.ConsumeIntInRange(-8, 256)
+    clip = fdp.ConsumeRegularFloat()
+
+    targets = (
+        (Experiment1.f, {"fast": fast, "slow": slow}),
+        (Experiment2.f, {"fast": fast, "slow": slow, "volatility": volatility}),
+        (Experiment3.f, {"fast": fast, "slow": slow, "vola": vola, "clip": clip}),
+        (Experiment4.f, {"fast": fast, "slow": slow, "vola": vola, "clip": clip}),
+        (Experiment5.f, {"fast": fast, "slow": slow, "vola": vola, "clip": clip}),
+    )
+    for signal, kwargs in targets:
+        with contextlib.suppress(_EXPECTED_SIGNAL_ERRORS):
+            frame.select(signal(pl.col("p"), **kwargs))
+
+
+def main() -> None:
+    """Run the Atheris fuzz loop."""
+    atheris.Setup(sys.argv, test_one_input)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Adds a fuzz suite to the repo, following the rhiza-cli convention used across the fleet (the only one of the sibling repos that still lacked any fuzzing).

- `tests/fuzz/fuzz_signal.py` — Atheris robustness harness over the `Experiment*.f` signal functions. `cs` has no parser/untrusted-input surface, so this fuzzes the numeric core: it synthesises a price series + the `fast/slow/vola/volatility/clip` params via `FuzzedDataProvider` and asserts each signal either evaluates or raises a documented `ValueError`/`TypeError`/`PolarsError`, never an unexpected crash.
- `.clusterfuzzlite/{project.yaml,Dockerfile,build.sh}` — build config; `build.sh` compiles each `tests/fuzz/fuzz_*.py` via OSS-Fuzz's `compile_python_fuzzer`.

## Notes
- `cs` declares no `[build-system]` and is not src-layout; the harness inserts `book/marimo/notebooks` on `sys.path` to import the notebook modules, mirroring how the existing tests load them.
- ⚠️ This repo has **no `rhiza_fuzzing.yml` workflow**, so the suite will not run in CI until that workflow is added (e.g. via a Rhiza sync). The harness is verified to byte-compile and the build script passes `bash -n`; `atheris` only runs in the OSS-Fuzz image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added fuzz testing coverage for signal-processing code to help catch crashes and edge-case failures earlier.

* **Tests**
  * Introduced a new fuzzing harness to exercise multiple signal paths with a wide range of inputs.

* **Chores**
  * Added configuration and build support for running fuzz tests in a ClusterFuzzLite environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->