### PR TITLE
docs: fix README Python prerequisite to 3.11+

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ opens the door to deeper insights into the strategy.
 
 ### 📋 Prerequisites
 
-- Python 3.12+
+- Python 3.11+
 - A POSIX shell. macOS and Linux have one by default.
 
 > **🪟 Windows users:** The `make` targets are written for a POSIX shell and


### PR DESCRIPTION
Closes #449

**What changed:** README Prerequisites updated from `Python 3.12+` to `Python 3.11+` to match `pyproject.toml` (`requires-python = ">=3.11"` and the 3.11 classifier).

**Confirming gate:** `make fmt` green — including "Check Python version consistency", "markdownlint", and the "Update README with Makefile help output" hooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)