### PR TITLE
chore: update rhiza to v1.0.0

### DIFF
--- a/.github/workflows/rhiza_benchmark.yml
+++ b/.github/workflows/rhiza_benchmark.yml
@@ -20,5 +20,5 @@ on:
 
 jobs:
   benchmark:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v0.19.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.0.0
     secrets: inherit

--- a/.github/workflows/rhiza_book.yml
+++ b/.github/workflows/rhiza_book.yml
@@ -29,7 +29,7 @@ permissions:
 
 jobs:
   book:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v0.19.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.0.0
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_ci.yml
+++ b/.github/workflows/rhiza_ci.yml
@@ -26,5 +26,5 @@ on:
 
 jobs:
   ci:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v0.19.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.0.0
     secrets: inherit

--- a/.github/workflows/rhiza_codeql.yml
+++ b/.github/workflows/rhiza_codeql.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   codeql:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v0.19.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.0.0
     secrets: inherit
     permissions:
       security-events: write   # Upload CodeQL results to code scanning

--- a/.github/workflows/rhiza_fuzzing.yml
+++ b/.github/workflows/rhiza_fuzzing.yml
@@ -34,7 +34,7 @@ permissions:
 
 jobs:
   fuzzing:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_fuzzing.yml@v0.19.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_fuzzing.yml@v1.0.0
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_marimo.yml
+++ b/.github/workflows/rhiza_marimo.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   marimo:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v0.19.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.0.0
     secrets: inherit

--- a/.github/workflows/rhiza_mutation.yml
+++ b/.github/workflows/rhiza_mutation.yml
@@ -42,7 +42,7 @@ jobs:
     # this repo sets the `MUTATION_ENABLED` variable to 'true'. Gating here in
     # the caller keeps it optional regardless of the pinned reusable workflow.
     if: ${{ vars.MUTATION_ENABLED == 'true' }}
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_mutation.yml@v0.19.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_mutation.yml@v1.0.0
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_release.yml
+++ b/.github/workflows/rhiza_release.yml
@@ -221,7 +221,7 @@ jobs:
           version: "0.11.16"
 
       - name: Configure git auth for private packages
-        uses: jebel-quant/rhiza/.github/actions/configure-git-auth@v0.19.9
+        uses: jebel-quant/rhiza/.github/actions/configure-git-auth@v1.0.0
         with:
           token: ${{ secrets.GH_PAT }}
 

--- a/.github/workflows/rhiza_scorecard.yml
+++ b/.github/workflows/rhiza_scorecard.yml
@@ -36,7 +36,7 @@ permissions: read-all
 
 jobs:
   scorecard:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v0.19.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.0.0
     secrets: inherit
     permissions:
       security-events: write   # Upload the SARIF results to code scanning

--- a/.github/workflows/rhiza_sync.yml
+++ b/.github/workflows/rhiza_sync.yml
@@ -35,7 +35,7 @@ on:
 
 jobs:
   sync:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_sync.yml@v0.19.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_sync.yml@v1.0.0
     with:
       direct: ${{ github.event_name == 'push' }}
       create-pr: ${{ github.event_name != 'push' && (github.event_name == 'schedule' || inputs.create-pr == true) }}

--- a/.github/workflows/rhiza_weekly.yml
+++ b/.github/workflows/rhiza_weekly.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   weekly:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v0.19.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.0.0
     secrets: inherit

--- a/.rhiza/template.lock
+++ b/.rhiza/template.lock
@@ -1,7 +1,7 @@
-sha: ff7bd135efaaad8aadf01d41bb60dd8419c015ae
+sha: 3186f09ecffa95a44148fbae02bc90d9e9dd05e2
 repo: jebel-quant/rhiza
 host: github
-ref: v0.19.9
+ref: v1.0.0
 include: []
 exclude:
 - .rhiza/docs/
@@ -106,5 +106,5 @@ files:
 - ruff.toml
 profiles:
 - github-project
-synced_at: '2026-06-28T18:07:49Z'
+synced_at: '2026-06-29T06:41:35Z'
 strategy: merge

--- a/.rhiza/template.yml
+++ b/.rhiza/template.yml
@@ -1,5 +1,5 @@
 template-repository: "jebel-quant/rhiza"
-template-branch: "v0.19.9"
+template-branch: "v1.0.0"
 
 profiles:
   - github-project


### PR DESCRIPTION
## Summary
- Bumps the template `template-branch` to `v1.0.0` in `.rhiza/template.yml` (was `v0.19.9` — a **major** version bump, confirmed by the maintainer before proceeding)
- Platform profile: `github-project` (unchanged — already matches the GitHub `origin`)
- Runs `make sync` to apply upstream template changes; sync applied cleanly with **no conflicts** (3-way merge: "All changes applied cleanly", no `.rej` files)
- `.rhiza/.rhiza-version` (the rhiza **tool** version) left untouched — only the template content ref moved

The v1.0.0 sync is minimal: it bumps the reusable-workflow refs `jebel-quant/rhiza/.github/workflows/*@v0.19.9 → @v1.0.0` across all 11 `.github/workflows/rhiza_*.yml` files, and updates `.rhiza/template.lock` (sha/ref/timestamp). No changes to project source, tests, or `pyproject.toml`.

## Quality gates

| Gate | Command | Result |
|------|---------|--------|
| Lint / format / pre-commit | `make fmt` | ✅ PASS (all hooks passed, no auto-fixes) |
| Type checking | `make typecheck` | ✅ PASS (`ty` + `mypy --strict`, 6 files, no issues) |
| Docstring coverage | `make docs-coverage` | ✅ PASS (interrogate 100.0%, min 100.0%) |
| Dependency hygiene | `make deptry` | ✅ PASS (no unused/missing/misplaced deps) |
| Security | `make security` | ✅ PASS (pip-audit: 0 vulns; bandit: clean) |
| Template validation | `make validate` | ✅ PASS (template.yml valid; ran `.rhiza` self-suite: 174 passed, 1 skipped, 100% cov) |
| Test suite + coverage | `make test` | ✅ PASS (project suite: 69 passed, 100% cov over `book/marimo/notebooks`, bar 100%) |

> Note: under rhiza v1.0.0, `make validate` runs the **Rhiza self-test suite** (`.rhiza/tests/*`, covering `.rhiza/utils`), not the project's own tests. The project suite (`tests/`) was therefore exercised separately via `make test`.

## Scorecard

Scope: locally-owned items only (`book/marimo/notebooks/`, `tests/`, `pyproject.toml`, `README.md`, `.rhiza/template.yml`, locally-hardened config). Rhiza-managed files (`.github/workflows/*`, `Makefile`, `.pre-commit-config.yaml`, `pytest.ini`, `ruff.toml`, `.rhiza/utils/*`, `.rhiza/tests/*`) are upstream-owned and out of scope.

| Subcategory | Score | Evidence | To raise |
|-------------|-------|----------|----------|
| Linting / style | 10/10 | `make fmt` clean, zero ruff format/check or markdownlint findings, no auto-fixes needed | — |
| Type safety | 10/10 | `ty` + `mypy --strict` pass over notebook code with no issues | — |
| Test pass rate | 10/10 | 69/69 project tests pass; 174/174 self-tests pass | — |
| Test coverage & depth | 10/10 | 100% line coverage over all 7 notebooks (436 stmts), meeting the locally-pinned `COVERAGE_FAIL_UNDER=100` bar | Add branch coverage / property-based edge cases for `optimize.py` (154 stmts) to deepen beyond line coverage |
| Code structure & readability | 9/10 | Clean marimo-notebook layout; `optimize.py` is the largest unit (154 stmts) | Consider factoring shared notebook logic into a small importable module to reduce duplication across `Experiment1–5` |
| Documentation | 9/10 | 100% docstring coverage (interrogate); README present and Python-version-consistent | Notebook-level narrative docs / an ADR for the optimization approach would raise it |
| Dependency & security hygiene | 10/10 | deptry clean; pip-audit 0 vulns; bandit clean; `uv.lock` in sync | — |
| CI / tooling health | 9/10 | All reusable workflows now pinned to `@v1.0.0`; profile matches host | Workflow definitions are upstream-owned (out of scope); the only local lever is keeping the template ref current — done here |

**Overall: 9.6 / 10.** This is a well-maintained repo: every gate is green, coverage and docstrings are at 100%, and types/security/deps are clean. The v1.0.0 bump is low-risk (workflow-ref-only diff).

**Highest-leverage improvement:** deepen test rigor on `optimize.py` — add branch-coverage and property/edge-case tests around the optimizer so the 100% line coverage reflects genuine behavioral depth, not just execution.
