### PR TITLE
quality: branch coverage, shared notebook loader, optimization docs (#453, #454, #455)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,14 @@ make install
 make book
 ```
 
+Developer notes live under [`docs/development/`](docs/development/):
+
+- [Parameter optimization](docs/development/OPTIMIZATION.md) — how the Optuna
+  search in `optimize.py` reuses the notebook signals (the
+  notebooks-are-the-source-of-truth contract).
+- [Sharpe-ratio pins](docs/development/SHARPE_PINS.md) — the pinned regression
+  baselines and how to update them.
+
 ### 🧪 Interactive Development
 
 ```bash

--- a/book/marimo/notebooks/optimize.py
+++ b/book/marimo/notebooks/optimize.py
@@ -20,7 +20,6 @@ strategy logic lives in the notebooks, the search space lives here.
 from __future__ import annotations
 
 import argparse
-import runpy
 import sys
 import warnings
 from collections.abc import Callable
@@ -37,7 +36,7 @@ from tinycta.signal import shrink2id
 NOTEBOOK_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(NOTEBOOK_DIR))
 
-from preamble import date_col, load_prices  # noqa: E402
+from preamble import date_col, load_notebook, load_prices  # noqa: E402
 
 # ── Data and signal functions (loaded once) ──────────────────────────────────
 
@@ -51,7 +50,7 @@ CLIP = 4.2
 
 def _signal(notebook: str) -> Callable[..., Any]:
     """Import the signal function ``f`` from an experiment notebook."""
-    return cast("Callable[..., Any]", runpy.run_path(str(NOTEBOOK_DIR / notebook))["f"])
+    return cast("Callable[..., Any]", load_notebook(notebook)["f"])
 
 
 F1 = _signal("Experiment1.py")

--- a/book/marimo/notebooks/preamble.py
+++ b/book/marimo/notebooks/preamble.py
@@ -1,6 +1,16 @@
-"""Shared data loading for marimo experiment notebooks."""
+"""Shared data loading for marimo experiment notebooks.
 
+This module also hosts :func:`load_notebook`, the single place that executes a
+sibling notebook (or ``optimize.py``) via :func:`runpy.run_path` and returns its
+namespace. The experiment notebooks are not an importable package, so both
+``optimize.py`` and the test suite need to read symbols (the signal ``f``, the
+``build_exp*`` builders, …) out of a freshly executed notebook namespace;
+centralizing that here keeps the ``runpy`` call in one place.
+"""
+
+import runpy
 from pathlib import Path
+from typing import Any
 
 import plotly.io as pio
 import polars as pl
@@ -9,6 +19,19 @@ from jquantstats import interpolate
 pio.renderers.default = "plotly_mimetype"
 
 date_col = "date"
+
+#: Directory holding the marimo notebooks (this file's own directory).
+NOTEBOOK_DIR = Path(__file__).resolve().parent
+
+
+def load_notebook(name: str) -> dict[str, Any]:
+    """Execute sibling notebook ``name`` (e.g. ``"Experiment1.py"``) and return its namespace.
+
+    The returned dict maps top-level names defined by the notebook to their
+    values, so callers can pull out the signal function with
+    ``load_notebook("Experiment1.py")["f"]``.
+    """
+    return runpy.run_path(str(NOTEBOOK_DIR / name))
 
 
 def load_prices(notebook_file: str) -> pl.DataFrame:

--- a/docs/development/OPTIMIZATION.md
+++ b/docs/development/OPTIMIZATION.md
@@ -1,0 +1,84 @@
+# Parameter optimization
+
+The experiment notebooks expose their strategy parameters as marimo sliders so
+you can tune the Sharpe ratio by hand. `book/marimo/notebooks/optimize.py`
+automates that tuning with [Optuna](https://optuna.org): it replays each
+notebook's exact portfolio construction and searches the parameter space for the
+configuration that maximizes the portfolio Sharpe ratio.
+
+## The notebooks-are-the-source-of-truth contract
+
+The single most important rule in this module:
+
+> **Strategy logic lives in the notebooks. Only the search space lives in
+> `optimize.py`.**
+
+Each `ExperimentN.py` notebook defines a signal function `f(...)`. `optimize.py`
+does **not** re-implement those signals — it imports the live `f` from each
+notebook and reuses it:
+
+```python
+from preamble import load_notebook
+
+f = load_notebook("Experiment1.py")["f"]
+```
+
+`load_notebook` (in `book/marimo/notebooks/preamble.py`) is the one place that
+executes a notebook via `runpy.run_path` and returns its namespace. The same
+helper is used by the test suite, so notebooks, the optimizer, and the tests all
+load strategy code through a single mechanism. This is what keeps the optimizer
+from silently drifting away from the notebooks it is supposed to optimize.
+
+The `build_exp*` functions in `optimize.py` mirror each notebook's portfolio
+cell (signal → positions → `Portfolio.from_cash_position`). They are tied to the
+notebooks numerically by the pinned Sharpe baselines in
+`tests/expected_sharpe.py` — see [SHARPE_PINS.md](SHARPE_PINS.md). If a builder
+stops reproducing its notebook's Sharpe ratio, the test suite fails.
+
+## How the search is structured
+
+| Piece | Role |
+| --- | --- |
+| `build_expN(...)` | Rebuilds experiment *N*'s portfolio for an explicit parameter set (mirrors the notebook cell). |
+| `objective_expN(trial)` | Samples a trial's parameters and returns the resulting portfolio Sharpe ratio. |
+| `_sharpe(portfolio)` | The optimization target: the annualized Sharpe ratio, mapped to `-inf` when non-finite so degenerate regions are discarded. |
+| `Experiment` / `EXPERIMENTS` | Registry binding each objective to its notebook-default parameters (the baseline reported against). |
+| `optimize(key, ...)` | Runs one Optuna study (TPE sampler, `direction="maximize"`) and prints baseline vs. best. |
+
+### Search spaces
+
+- `fast`, `slow`, `vola`, `volatility` mirror the marimo sliders: `4..192` in
+  steps of `4`.
+- `slow` is always drawn **strictly above** `fast` (`_suggest_fast_slow`) so the
+  crossover keeps its fast/slow meaning and the oscillator stays well-defined.
+- `clip` is held fixed at `4.2` (`CLIP`) rather than searched — it is a
+  winsorizing level, not a strategy dimension.
+- Experiment 5 additionally searches `corr` (`50..500`) and `shrinkage`
+  (`0.0..1.0`), holding `fast`/`slow` at the notebook's fixed `32`/`96`.
+
+`DEFAULT_TRIALS` sets a per-experiment trial budget — Experiment 5 evaluates a
+per-row matrix solve (~3 s/trial) and so gets fewer trials than the sub-second
+experiments.
+
+## Running it
+
+```bash
+# Optimize one experiment
+python book/marimo/notebooks/optimize.py --experiment 3 --trials 200
+
+# Optimize all of them with the per-experiment default budgets
+python book/marimo/notebooks/optimize.py --experiment all
+
+# Reproducible runs and Optuna's per-trial logging
+python book/marimo/notebooks/optimize.py -e 1 -n 50 --seed 7 --verbose
+```
+
+Each run prints the baseline Sharpe (notebook defaults), the best Sharpe found,
+the winning parameters, and the improvement.
+
+## Testing
+
+`tests/test_optimize.py` covers the builders, the objectives, the search-space
+bounds, and the CLI entry point. Coverage is measured with **branch** coverage
+enabled (`[tool.coverage.run] branch = true` in `pyproject.toml`) at a 100%
+threshold, so every guard and dispatch branch in `optimize.py` is exercised.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,10 @@ module = ["jquantstats.*", "tinycta.*", "plotly.*"]
 ignore_missing_imports = true
 
 [tool.coverage.run]
+# Measure branch coverage, not just line coverage, so a conditional that is only
+# ever taken one way (e.g. a guard whose else-branch is never exercised) is
+# reported as a partial branch rather than counting as fully covered.
+branch = true
 # The notebook regression tests execute each marimo notebook in a spawned
 # child process for isolation. Without subprocess tracking, the cell bodies
 # they run would not be counted. parallel+multiprocessing+patch let coverage

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,8 +5,20 @@ Security Notes:
 - Test code operates in a controlled environment with trusted inputs.
 """
 
+import sys
+from pathlib import Path
+
 import polars as pl
 import pytest
+
+# Bootstrap the notebook directory onto sys.path once, here, so every test
+# module can ``from preamble import load_notebook`` (the shared notebook loader)
+# instead of repeating its own ``sys.path`` + ``runpy`` boilerplate. The
+# notebooks are not an importable package, so this single insert is the price of
+# reaching their shared ``preamble`` helper module.
+NOTEBOOK_DIR = (Path(__file__).resolve().parents[1] / "book" / "marimo" / "notebooks").resolve()
+if str(NOTEBOOK_DIR) not in sys.path:
+    sys.path.insert(0, str(NOTEBOOK_DIR))
 
 N = 600  # satisfies min_samples=300 (the highest requirement across all experiments)
 

--- a/tests/test_experiment1.py
+++ b/tests/test_experiment1.py
@@ -1,14 +1,9 @@
 """Tests for the signal function f defined in Experiment 1."""
 
-import runpy
-from pathlib import Path
-
 import polars as pl
+from preamble import load_notebook
 
-ROOT = Path(__file__).resolve().parents[1]
-NOTEBOOK_DIR = ROOT / "book" / "marimo" / "notebooks"
-
-f = runpy.run_path(str(NOTEBOOK_DIR / "Experiment1.py"))["f"]
+f = load_notebook("Experiment1.py")["f"]
 
 
 def test_f_signal_values_are_sign(rising):

--- a/tests/test_experiment2.py
+++ b/tests/test_experiment2.py
@@ -1,14 +1,9 @@
 """Tests for the signal function f defined in Experiment 2."""
 
-import runpy
-from pathlib import Path
-
 import polars as pl
+from preamble import load_notebook
 
-ROOT = Path(__file__).resolve().parents[1]
-NOTEBOOK_DIR = ROOT / "book" / "marimo" / "notebooks"
-
-f = runpy.run_path(str(NOTEBOOK_DIR / "Experiment2.py"))["f"]
+f = load_notebook("Experiment2.py")["f"]
 
 
 def test_f_rising_trend_gives_positive_signal(rising):

--- a/tests/test_experiment3.py
+++ b/tests/test_experiment3.py
@@ -1,14 +1,9 @@
 """Tests for the signal function f defined in Experiment 3."""
 
-import runpy
-from pathlib import Path
-
 import polars as pl
+from preamble import load_notebook
 
-ROOT = Path(__file__).resolve().parents[1]
-NOTEBOOK_DIR = ROOT / "book" / "marimo" / "notebooks"
-
-f = runpy.run_path(str(NOTEBOOK_DIR / "Experiment3.py"))["f"]
+f = load_notebook("Experiment3.py")["f"]
 
 
 def test_f_rising_trend_gives_positive_signal(rising):

--- a/tests/test_experiment4.py
+++ b/tests/test_experiment4.py
@@ -1,14 +1,9 @@
 """Tests for the signal function f defined in Experiment 4."""
 
-import runpy
-from pathlib import Path
-
 import polars as pl
+from preamble import load_notebook
 
-ROOT = Path(__file__).resolve().parents[1]
-NOTEBOOK_DIR = ROOT / "book" / "marimo" / "notebooks"
-
-f = runpy.run_path(str(NOTEBOOK_DIR / "Experiment4.py"))["f"]
+f = load_notebook("Experiment4.py")["f"]
 
 
 def test_f_signal_is_bounded_by_tanh(rising):

--- a/tests/test_experiment5.py
+++ b/tests/test_experiment5.py
@@ -1,14 +1,9 @@
 """Tests for the signal function f defined in Experiment 5."""
 
-import runpy
-from pathlib import Path
-
 import polars as pl
+from preamble import load_notebook
 
-ROOT = Path(__file__).resolve().parents[1]
-NOTEBOOK_DIR = ROOT / "book" / "marimo" / "notebooks"
-
-f = runpy.run_path(str(NOTEBOOK_DIR / "Experiment5.py"))["f"]
+f = load_notebook("Experiment5.py")["f"]
 
 
 def test_f_signal_is_bounded_by_tanh(rising):

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -1,10 +1,8 @@
 """Tests for the Optuna parameter-optimization module (optimize.py)."""
 
 import math
-import runpy
-import sys
-from pathlib import Path
 
+import numpy as np
 import optuna
 import pytest
 from expected_sharpe import (
@@ -12,12 +10,9 @@ from expected_sharpe import (
     SHARPE_RATIO_ABS_TOLERANCE,
     SHARPE_RATIO_REL_TOLERANCE,
 )
+from preamble import load_notebook
 
-ROOT = Path(__file__).resolve().parents[1]
-NOTEBOOK_DIR = ROOT / "book" / "marimo" / "notebooks"
-sys.path.insert(0, str(NOTEBOOK_DIR))
-
-optimize = runpy.run_path(str(NOTEBOOK_DIR / "optimize.py"))
+optimize = load_notebook("optimize.py")
 
 # Keep Optuna quiet during the test run.
 optuna.logging.set_verbosity(optuna.logging.WARNING)
@@ -106,3 +101,69 @@ def test_main_runs_single_experiment(capsys):
     out = capsys.readouterr().out
     assert "Experiment 1" in out
     assert "best Sharpe" in out
+
+
+def test_default_trials_cover_every_experiment():
+    """DEFAULT_TRIALS has an entry for each registered experiment (no KeyError in main)."""
+    assert set(optimize["DEFAULT_TRIALS"]) == set(optimize["EXPERIMENTS"])
+
+
+def test_sharpe_returns_neg_inf_for_nonfinite_portfolio():
+    """A degenerate (all-zero) portfolio has a non-finite Sharpe, mapped to -inf.
+
+    Exercises the ``else float('-inf')`` branch of ``_sharpe`` that the search
+    relies on to discard parameter regions that produce no usable returns.
+    """
+    zeros = np.zeros((len(optimize["PRICES_ONLY"]), len(optimize["ASSETS"])))
+    portfolio = optimize["_portfolio_from_matrix"](zeros)
+    assert optimize["_sharpe"](portfolio) == float("-inf")
+
+
+def test_suggest_fast_slow_stays_within_slider_bounds():
+    """Sampled (fast, slow) pairs honor the slider ranges and the fast < slow rule.
+
+    Checks the boundaries of the shared ``_suggest_fast_slow`` search space:
+    fast in [4, 96], slow in [fast+4, 192], both multiples of 4.
+    """
+    study = optuna.create_study(direction="maximize", sampler=optuna.samplers.TPESampler(seed=1))
+    study.optimize(optimize["objective_exp1"], n_trials=15)
+    for trial in study.trials:
+        fast, slow = trial.params["fast"], trial.params["slow"]
+        assert 4 <= fast <= 96
+        assert fast % 4 == 0
+        assert fast + 4 <= slow <= 192
+        assert slow % 4 == 0
+
+
+def test_objective_exp5_samples_within_search_space():
+    """Experiment 5's objective samples vola/corr/shrinkage within their declared ranges."""
+    study = optuna.create_study(direction="maximize", sampler=optuna.samplers.TPESampler(seed=2))
+    study.optimize(optimize["objective_exp5"], n_trials=2)
+    for trial in study.trials:
+        assert 4 <= trial.params["vola"] <= 192
+        assert 50 <= trial.params["corr"] <= 500
+        assert 0.0 <= trial.params["shrinkage"] <= 1.0
+
+
+def test_main_experiment_all_uses_default_trials_for_every_experiment(capsys, monkeypatch):
+    """``--experiment all`` (no ``--trials``) dispatches to all experiments using DEFAULT_TRIALS.
+
+    Exercises both the ``"all"`` key expansion and the
+    ``n_trials = ... else DEFAULT_TRIALS[key]`` fallback branch in ``main``.
+    DEFAULT_TRIALS is shrunk to a single trial each to keep the test fast.
+    """
+    for key in optimize["EXPERIMENTS"]:
+        monkeypatch.setitem(optimize["DEFAULT_TRIALS"], key, 1)
+    optimize["main"](["--experiment", "all"])
+    out = capsys.readouterr().out
+    for experiment in optimize["EXPERIMENTS"].values():
+        assert experiment.name in out
+
+
+def test_main_verbose_enables_optuna_logging(capsys, monkeypatch):
+    """The ``--verbose`` flag leaves Optuna's per-trial logging enabled (skips the silencing branch)."""
+    calls = []
+    monkeypatch.setattr(optuna.logging, "set_verbosity", lambda level: calls.append(level))
+    optimize["main"](["--experiment", "1", "--trials", "1", "--verbose"])
+    # With --verbose, main must not silence Optuna by lowering verbosity to WARNING.
+    assert optuna.logging.WARNING not in calls

--- a/tests/test_preamble.py
+++ b/tests/test_preamble.py
@@ -1,17 +1,15 @@
 """Tests for the preamble module shared by marimo experiment notebooks."""
 
-import runpy
 from pathlib import Path
 
 import plotly.io as pio
 import polars as pl
 import pytest
+from preamble import NOTEBOOK_DIR, load_notebook
 
-ROOT = Path(__file__).resolve().parents[1]
-NOTEBOOK_DIR = ROOT / "book" / "marimo" / "notebooks"
 NOTEBOOK_FILE = str(NOTEBOOK_DIR / "Experiment1.py")
 
-preamble = runpy.run_path(str(NOTEBOOK_DIR / "preamble.py"))
+preamble = load_notebook("preamble.py")
 load_prices = preamble["load_prices"]
 date_col = preamble["date_col"]
 


### PR DESCRIPTION
## Summary

Addresses the three quality-assessment recommendations from the `/rhiza_quality` scorecard. All seven gates remain green.

Closes #453
Closes #454
Closes #455

### #453 — Deepen `optimize.py` test rigor (Test coverage & depth 9→10)
- Enable **branch coverage** (`[tool.coverage.run] branch = true` in `pyproject.toml`).
- New tests in `tests/test_optimize.py` for the previously-untested branches:
  - CLI dispatch: `--experiment all`, default-vs-explicit `--trials`, `--verbose`.
  - Search-space bounds: `_suggest_fast_slow` (fast/slow ranges, `fast < slow`, step-4) and `objective_exp5` (vola/corr/shrinkage ranges).
  - The `_sharpe` non-finite → `-inf` branch (degenerate all-zero portfolio).
- `optimize.py` now reports **100% branch coverage** (14 branches, 0 partial). Suite: 69 → 75 tests, still 100% at the configured bar.

### #454 — Extract the notebook-loader shim (Code structure 9→10)
- Add `load_notebook(name)` + `NOTEBOOK_DIR` to `book/marimo/notebooks/preamble.py` — the **single** place that runs a notebook via `runpy.run_path` and returns its namespace.
- `optimize.py` (`_signal`) and all test modules now load notebooks through it; the repeated `ROOT`/`NOTEBOOK_DIR`/`sys.path.insert`/`runpy.run_path` boilerplate is gone.
- Tests bootstrap the notebook dir onto `sys.path` once in `tests/conftest.py`.
- Removed a redundant `sys.path` insert from `preamble` (notebooks self-insert; `optimize.py` and conftest cover the rest).

### #455 — Document the optimization approach (Documentation 9→10)
- New `docs/development/OPTIMIZATION.md`: the Optuna search design (objective, samplers, per-experiment search spaces, fixed `clip`, `fast < slow`, `DEFAULT_TRIALS`) and the **notebooks-are-the-source-of-truth** contract.
- Linked from `README.md` (Documentation section).

## Quality gates

| Gate | Result |
|------|--------|
| `make fmt` | ✅ PASS |
| `make typecheck` | ✅ PASS |
| `make docs-coverage` | ✅ PASS (100%) |
| `make deptry` | ✅ PASS |
| `make security` | ✅ PASS |
| `make validate` | ✅ PASS |
| `make test` | ✅ PASS (75 passed, 100% **branch** coverage over `book/marimo/notebooks`) |

## Notes / scope
- `tests/test_notebook_sharpe.py` keeps its own `runpy` call: it executes notebooks **end-to-end in a spawned subprocess** (`run_name="__main__"`, stdout capture) — a different mechanism from the load-namespace-by-name shim, so it is intentionally not folded into `load_notebook`.
- All changes are in locally-owned files; nothing Rhiza-managed was touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
