### PR TITLE
chore: type-check Experiment notebooks and drop sys.path hack (#483, #490)

### DIFF
--- a/book/marimo/notebooks/Experiment1.py
+++ b/book/marimo/notebooks/Experiment1.py
@@ -43,7 +43,7 @@ def _():
 
 
 @app.function
-def f(price: "pl.Expr", fast=32, slow=96) -> "pl.Expr":
+def f(price: "pl.Expr", fast: int = 32, slow: int = 96) -> "pl.Expr":
     """Return the sign of the fast-minus-slow EWM crossover."""
     return (price.ewm_mean(com=fast, min_samples=100) - price.ewm_mean(com=slow, min_samples=100)).sign()
 

--- a/book/marimo/notebooks/Experiment2.py
+++ b/book/marimo/notebooks/Experiment2.py
@@ -43,7 +43,7 @@ def _():
 
 
 @app.function
-def f(price: "pl.Expr", fast=32, slow=96, volatility=32) -> "pl.Expr":
+def f(price: "pl.Expr", fast: int = 32, slow: int = 96, volatility: int = 32) -> "pl.Expr":
     """Return the volatility-scaled EWM crossover signal."""
     return (
         price.ewm_mean(com=fast, min_samples=300) - price.ewm_mean(com=slow, min_samples=300)

--- a/book/marimo/notebooks/Experiment3.py
+++ b/book/marimo/notebooks/Experiment3.py
@@ -91,7 +91,7 @@ def _():
 
 
 @app.function
-def f(price: "pl.Expr", slow=96, fast=32, vola=96, clip=3) -> "pl.Expr":
+def f(price: "pl.Expr", slow: int = 96, fast: int = 32, vola: int = 96, clip: float = 3) -> "pl.Expr":
     """Return the tanh oscillator of vol-adjusted cumulative price, divided by volatility."""
     price_adj = vol_adj(price, vola=vola, clip=clip, min_samples=300).cum_sum()
     mu = osc(price_adj, fast=fast, slow=slow).tanh()

--- a/book/marimo/notebooks/Experiment4.py
+++ b/book/marimo/notebooks/Experiment4.py
@@ -49,7 +49,7 @@ def _():
 
 
 @app.function
-def f(price: "pl.Expr", fast=32, slow=96, vola=32, clip=4.2) -> "pl.Expr":
+def f(price: "pl.Expr", fast: int = 32, slow: int = 96, vola: int = 32, clip: float = 4.2) -> "pl.Expr":
     """Return the tanh oscillator of vol-adjusted cumulative price."""
     return osc(vol_adj(price, vola=vola, clip=clip, min_samples=300).cum_sum(), fast=fast, slow=slow).tanh()
 

--- a/book/marimo/notebooks/Experiment5.py
+++ b/book/marimo/notebooks/Experiment5.py
@@ -53,7 +53,7 @@ def _():
 
 
 @app.function
-def f(price: "pl.Expr", fast=32, slow=96, vola=32, clip=4.2) -> "pl.Expr":
+def f(price: "pl.Expr", fast: int = 32, slow: int = 96, vola: int = 32, clip: float = 4.2) -> "pl.Expr":
     """Return the tanh oscillator of vol-adjusted cumulative price."""
     return osc(vol_adj(price, vola=vola, clip=clip, min_samples=300).cum_sum(), fast=fast, slow=slow).tanh()
 
@@ -115,7 +115,7 @@ def correlation_from_covariance(cov_np: "np.ndarray") -> "np.ndarray":
     _var = cov_np[:, np.arange(n_assets), np.arange(n_assets)]
     with np.errstate(invalid="ignore", divide="ignore"):
         _denom = np.sqrt(_var[:, :, None] * _var[:, None, :])
-        cor_3d = cov_np / _denom
+        cor_3d: np.ndarray = cov_np / _denom
     for _k in range(n_assets):
         cor_3d[_var[:, _k] > 0, _k, _k] = 1.0
     return cor_3d

--- a/book/marimo/notebooks/optimize.py
+++ b/book/marimo/notebooks/optimize.py
@@ -12,7 +12,6 @@ logic thus lives once in the notebooks; only the search space lives here. Run it
 from __future__ import annotations
 
 import argparse
-import sys
 import warnings
 from collections.abc import Callable
 from functools import cache
@@ -23,13 +22,15 @@ import numpy as np
 import optuna
 import polars as pl
 from jquantstats import Portfolio
+
+# ``preamble`` (the notebooks' shared loader) resolves because this script's own
+# directory is already on ``sys.path`` — put there by the interpreter for
+# ``python optimize.py`` and by the test ``conftest`` for the ``runpy`` path.
+from preamble import date_col, load_notebook, load_prices
 from tinycta.linalg import inv_a_norm, solve
 from tinycta.signal import shrink2id
 
 NOTEBOOK_DIR = Path(__file__).resolve().parent
-sys.path.insert(0, str(NOTEBOOK_DIR))
-
-from preamble import date_col, load_notebook, load_prices  # noqa: E402
 
 # Data/signal accessors are ``@cache``d, so importing this module reads no CSV and
 # runs no notebook. ``clip`` is a fixed winsorizing level, not a search dimension.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,18 +42,6 @@ index-strategy = "unsafe-best-match"
 package_module_name_map = { marimo = "marimo", numpy = "numpy", polars = "polars", plotly = "plotly" }
 
 [tool.mypy]
-# The Experiment*.py notebooks are marimo-generated, not hand-written source.
-# Their structure is scaffolding mypy --strict cannot check without defeating the
-# point: every cell is an untyped ``@app.cell``-decorated ``_()`` function (so
-# --strict reports untyped-decorator + no-untyped-def on generated code), and
-# marimo ships no type stubs (import-not-found). Annotating that generated
-# scaffolding by hand would be wiped the next time marimo rewrites a notebook, so
-# it buys no lasting safety. Their *behaviour* is instead pinned end-to-end by the
-# Sharpe regression tests (tests/test_notebook_sharpe.py), which execute each
-# notebook and assert its numeric output. The hand-written modules that carry the
-# real logic — optimize.py, preamble.py — are fully checked under mypy --strict,
-# matching the template's typecheck gate.
-exclude = '(Experiment.*\.py)$'
 mypy_path = "book/marimo/notebooks"
 strict = true
 
@@ -61,6 +49,20 @@ strict = true
 # No type stubs published for these.
 module = ["jquantstats.*", "tinycta.*", "plotly.*"]
 ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+# The Experiment*.py notebooks are marimo-generated. Their hand-written logic — the
+# ``f`` signal functions and the Experiment 5 DCC helpers — is fully checked under
+# --strict. What is deliberately *not* checked is the generated cell scaffolding:
+# marimo emits every cell as a ``@app.cell``-decorated ``_(...)`` function with no
+# annotations, and annotating that generated ``def _()`` boilerplate by hand would
+# be wiped the next time marimo rewrites the notebook, so it buys no lasting safety.
+# ``no-untyped-def`` is the only error code those generated cells raise, so we
+# disable just that code for these modules — rather than excluding the whole files —
+# keeping the real strategy logic under the type checker. Behaviour is additionally
+# pinned end-to-end by the Sharpe regression tests (tests/test_notebook_sharpe.py).
+module = ["Experiment1", "Experiment2", "Experiment3", "Experiment4", "Experiment5"]
+disable_error_code = ["no-untyped-def"]
 
 [tool.coverage.run]
 # Measure branch coverage, not just line coverage, so a conditional that is only


### PR DESCRIPTION
Addresses two of the open quality-scorecard follow-ups.

## Closes #483 — type-check the `Experiment*` marimo notebooks
Previously `[tool.mypy] exclude = '(Experiment.*\.py)$'` skipped all five notebooks wholesale, so `mypy --strict` only ever checked `optimize.py` and `preamble.py` (2 files).

- Replaced the whole-module exclude with a **narrow per-module override** that disables only `no-untyped-def` — the single error code marimo's generated `@app.cell def _(...)` cells raise. Everything else stays under `--strict`.
- Annotated the hand-written `f(...)` signal-function parameters in Experiment1–5 and the Experiment 5 `correlation_from_covariance` local, so the real strategy logic passes `--strict` on its own (the disabled code now only silences generated cell scaffolding, which marimo would overwrite anyway).
- `mypy --strict` now covers **7 source files instead of 2**, and passes.

This follows the issue's second suggested direction (narrow the exclusion so only generated cell scaffolding is skipped, not whole modules).

## Closes #490 — no import-time `sys.path` mutation in `optimize.py`
`optimize.py` did `sys.path.insert(0, NOTEBOOK_DIR)` at import time and needed a `# noqa: E402` on the `from preamble import ...` that followed it.

- The notebook directory is already on `sys.path` in both real execution paths — the interpreter puts the script's dir there for `python optimize.py`, and the test `conftest` does the same for the `runpy` path — so the import is hoisted to the top block and the mutation + noqa are removed.
- No `sys.path` side effect remains on import; `optimize.py` stays at **300 lines**, keeping #484 satisfied.

## Verification
- `mypy --strict book/marimo/notebooks` → success, 7 files
- `ruff check` / `ruff format` → clean
- `pytest tests/` → 76 passed (notebook + optimizer Sharpe regressions still match the pinned 1e-6 baselines — annotations are runtime no-ops)
- `make marimo-validate` → all notebooks valid
- `interrogate` → 100% docstring coverage
- radon → no block above grade A

> Note: the local `check-inline-pins` pre-commit hook crashes with `ModuleNotFoundError: No module named 'tomllib'` because it runs under a pre-3.11 Python; the check itself passes under `uv run python scripts/check_inline_pins.py`. Pre-existing infra issue, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)