### PR TITLE
chore(pyproject): modernize Python version and license metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
-    "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,8 @@ description = "Companion materials for the Computational Statistics project."
 readme = "README.md"
 requires-python = ">=3.11"
 authors = [{ name = "Thomas Schmelzer" }]
-license = { file = "LICENSE" }
+license = "MIT"
+license-files = ["LICENSE"]
 dependencies = [
     "marimo>=0.23.14",
     "numpy>=2.4.6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Science/Research",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",


### PR DESCRIPTION
Modernizes the `[project]` metadata in `pyproject.toml`.

**Python versions** — one explicit trove classifier per supported version instead of the generic `Programming Language :: Python :: 3` rows. `requires-python` is 3.11", so the classifiers are: **3.11,3.12,3.13,3.14**.

**License** — dropped the `License :: ...` classifiers, which PEP 639 deprecates in favour of the `license` SPDX expression plus `license-files`. Backends implementing PEP 639 reject a project that declares both.

**SPDX** — moved the `license` key from the deprecated table form to a PEP 639 SPDX expression.

Metadata only — no source, dependency, or tooling changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
