### PR TITLE
chore: update rhiza to v1.2.4

### DIFF
--- a/.github/workflows/rhiza_benchmark.yml
+++ b/.github/workflows/rhiza_benchmark.yml
@@ -20,5 +20,5 @@ on:
 
 jobs:
   benchmark:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.2.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.2.4
     secrets: inherit

--- a/.github/workflows/rhiza_book.yml
+++ b/.github/workflows/rhiza_book.yml
@@ -29,7 +29,7 @@ permissions:
 
 jobs:
   book:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.2.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.2.4
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_ci.yml
+++ b/.github/workflows/rhiza_ci.yml
@@ -26,5 +26,5 @@ on:
 
 jobs:
   ci:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.2.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.2.4
     secrets: inherit

--- a/.github/workflows/rhiza_codeql.yml
+++ b/.github/workflows/rhiza_codeql.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   codeql:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.2.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.2.4
     secrets: inherit
     permissions:
       security-events: write   # Upload CodeQL results to code scanning

--- a/.github/workflows/rhiza_fuzzing.yml
+++ b/.github/workflows/rhiza_fuzzing.yml
@@ -34,7 +34,7 @@ permissions:
 
 jobs:
   fuzzing:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_fuzzing.yml@v1.2.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_fuzzing.yml@v1.2.4
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_marimo.yml
+++ b/.github/workflows/rhiza_marimo.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   marimo:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.2.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.2.4
     secrets: inherit

--- a/.github/workflows/rhiza_mutation.yml
+++ b/.github/workflows/rhiza_mutation.yml
@@ -42,7 +42,7 @@ jobs:
     # this repo sets the `MUTATION_ENABLED` variable to 'true'. Gating here in
     # the caller keeps it optional regardless of the pinned reusable workflow.
     if: ${{ vars.MUTATION_ENABLED == 'true' }}
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_mutation.yml@v1.2.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_mutation.yml@v1.2.4
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_release.yml
+++ b/.github/workflows/rhiza_release.yml
@@ -222,7 +222,7 @@ jobs:
           version: "0.11.16"
 
       - name: Configure git auth for private packages
-        uses: jebel-quant/rhiza/.github/actions/configure-git-auth@v1.2.2
+        uses: jebel-quant/rhiza/.github/actions/configure-git-auth@v1.2.4
         with:
           token: ${{ secrets.GH_PAT }}
 

--- a/.github/workflows/rhiza_scorecard.yml
+++ b/.github/workflows/rhiza_scorecard.yml
@@ -36,7 +36,7 @@ permissions: read-all
 
 jobs:
   scorecard:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.2.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.2.4
     secrets: inherit
     permissions:
       security-events: write   # Upload the SARIF results to code scanning

--- a/.github/workflows/rhiza_weekly.yml
+++ b/.github/workflows/rhiza_weekly.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   weekly:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.2.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.2.4
     secrets: inherit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,7 @@ repos:
         files: '^(book/marimo/notebooks/.*\.py|tests/.*\.py)$'
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 'v0.15.21'
+    rev: 'v0.16.0'
     hooks:
       - id: ruff
         args: [ --fix, --exit-non-zero-on-fix, --unsafe-fixes ]
@@ -85,12 +85,12 @@ repos:
         args: ["--ini", ".bandit", "--exclude", ".venv,tests,.rhiza/tests,.git,.pytest_cache"]
 
   - repo: https://github.com/betterleaks/betterleaks
-    rev: v1.6.1
+    rev: v1.7.2
     hooks:
       - id: betterleaks
 
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.11.28
+    rev: 0.12.0
     hooks:
       - id: uv-lock
 

--- a/.rhiza/.cfg.toml
+++ b/.rhiza/.cfg.toml
@@ -28,10 +28,22 @@ values = [
     "prod"
 ]
 
+# Anchored to the [project] table on purpose. `search`/`replace` are applied to
+# EVERY occurrence in the file, so the obvious `version = "{current_version}"`
+# also rewrites any [tool.*] table that happens to share the current number.
+# Dependency pins (httpx>=1.2.0, rich==1.2.0) are never at risk either way —
+# they are not line-anchored `version = ` assignments — but a second table is.
 [[tool.bumpversion.files]]
 filename = "pyproject.toml"
-search = 'version = "{current_version}"'
-replace = 'version = "{new_version}"'
+regex = true
+search = '(?ms)^\[project\]((?:(?!^\[)[\s\S])*?)^version = "{current_version}"'
+replace = '[project]\1version = "{new_version}"'
+
+# NOTE for downstream projects: do NOT add a glob over your own
+# .github/workflows/*.yml here. Those stubs pin jebel-quant/rhiza's version
+# (the template you sync from), not your project's, so rewriting them with your
+# version would point them at a rhiza tag that does not exist. The template ref
+# is managed by /rhiza:update via .rhiza/template.yml instead.
 
 # Keep the reusable-workflow stubs in the bundles pinned to the current release.
 # These stubs are synced into downstream repos and must reference an existing tag.

--- a/.rhiza/template.lock
+++ b/.rhiza/template.lock
@@ -1,7 +1,7 @@
-sha: e0fe02300840e39fe75d19db2741e9a790f87794
+sha: b5ee2ae1e4807b77e7106965986b09523b8f1d34
 repo: jebel-quant/rhiza
 host: github
-ref: v1.2.1
+ref: v1.2.4
 include: []
 exclude: []
 templates:
@@ -54,7 +54,6 @@ files:
 - .rhiza/make.d/github.mk
 - .rhiza/make.d/marimo.mk
 - .rhiza/make.d/quality.mk
-- .rhiza/make.d/releasing.mk
 - .rhiza/make.d/test.mk
 - .rhiza/rhiza.mk
 - .rhiza/semgrep.yml
@@ -74,5 +73,5 @@ files:
 - docs/mkdocs-base.yml
 - pytest.ini
 - ruff.toml
-synced_at: '2026-07-17T05:23:43Z'
+synced_at: '2026-07-29T19:09:56Z'
 strategy: merge

--- a/.rhiza/template.yml
+++ b/.rhiza/template.yml
@@ -1,5 +1,5 @@
 repository: "jebel-quant/rhiza"
-ref: "v1.2.1"
+ref: "v1.2.4"
 
 profiles:
   - github-project

--- a/.rhiza/tests/test_pyproject.py
+++ b/.rhiza/tests/test_pyproject.py
@@ -140,7 +140,7 @@ class TestProjectUrls:
 
 
 class TestProjectClassifiers:
-    """Tests for [project].classifiers — Python version and licence entries."""
+    """Tests for [project].classifiers — Python version entries."""
 
     @pytest.fixture
     def classifiers(self, project: dict) -> list[str]:
@@ -157,10 +157,17 @@ class TestProjectClassifiers:
             "classifiers must include at least one 'Programming Language :: Python :: 3.X' entry"
         )
 
-    def test_license_classifier_present(self, classifiers: list[str]) -> None:
-        """At least one 'License :: ' classifier must be present."""
+    def test_no_license_classifier(self, project: dict) -> None:
+        """No deprecated 'License :: ' classifier may be present.
+
+        PyPI has deprecated the ``License ::`` trove classifiers in favor of the SPDX
+        ``license`` expression field, so the shipped pyproject must not declare one.
+        """
+        classifiers = project.get("classifiers", [])
         license_classifiers = [c for c in classifiers if c.startswith("License ::")]
-        assert len(license_classifiers) >= 1, "classifiers must include at least one 'License :: ' entry"
+        assert not license_classifiers, (
+            f"classifiers must not include any deprecated 'License :: ' entry; found {license_classifiers}"
+        )
 
 
 class TestDependencyGroups:

--- a/ruff.toml
+++ b/ruff.toml
@@ -3,8 +3,7 @@
 #
 # Maximum line length for the entire project
 line-length = 120
-# Target Python version
-target-version = "py311"
+# Target Python version is inferred from project.requires-python.
 
 # Exclude directories with Jinja template variables in their names
 exclude = ["**/[{][{]*/", "**/*[}][}]*/"]


### PR DESCRIPTION
Syncs this repo to the latest release of its template.

- **Template:** `jebel-quant/rhiza`
- **Ref:** `v1.2.1` → `v1.2.4` (upstream commit `b5ee2ae1e480`)

## What changed

15 template-owned files updated (42 insertions, 25 deletions):

- `.github/workflows/rhiza_*.yml` (10 files) — stub pin bumps
- `.pre-commit-config.yaml`
- `.rhiza/.cfg.toml`
- `.rhiza/tests/test_pyproject.py`
- `ruff.toml`
- `.rhiza/template.lock` + `.rhiza/template.yml`

## Conflicts

10 workflow stubs conflicted and were resolved by **taking the upstream (template) side** — these files are template-owned, so local divergence is drift to undo rather than work to preserve.

## Left unstaged

- `.rhiza/make.d/releasing.mk` — the sync removed this file (it is gone from the upstream template) but it is not in the new lock's `files` list, so the deletion was deliberately **not** staged. It remains a pending deletion in the working tree for the repo owner to decide on.

## Gates

**No quality gates were run** in this PR — `/update` only syncs. Run `/rhiza:quality` for a scorecard.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated benchmark, CI, documentation, security, release, and maintenance workflows.
  * Refreshed code-quality, secret-scanning, and package-management tooling.

* **Bug Fixes**
  * Improved version updates to modify only the project’s intended version field.
  * Prevented use of deprecated license classifiers in project metadata.
  * Enabled Ruff to infer the Python target version from project settings.

* **Documentation**
  * Updated the repository template reference and clarified versioning configuration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->