### PR TITLE
Show the coverage badge in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![pages-build-deployment](https://github.com/tschm/cs/actions/workflows/pages/pages-build-deployment/badge.svg)](https://github.com/tschm/cs/actions/workflows/pages/pages-build-deployment)
 [![CodeFactor](https://www.codefactor.io/repository/github/tschm/cs/badge)](https://www.codefactor.io/repository/github/tschm/cs)
+[![Coverage](https://tschm.github.io/cs/coverage-badge.svg)](https://tschm.github.io/cs/reports/html-coverage/)
 [![Renovate enabled](https://img.shields.io/badge/renovate-enabled-brightgreen.svg)](https://github.com/renovatebot/renovate)
 
 ## 🚀 About


### PR DESCRIPTION
Coverage is already measured, published and sitting at **100%** — the badge SVG and the HTML report are both live — but the README never linked either, so the number was reachable only by knowing the URL.

It also left the coverage column blank for this row in the [tschm profile table](https://github.com/tschm/tschm), which harvests the badge from each repository's own README rather than reconstructing it, so that a project decides for itself what it publishes and under which URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a test coverage badge to the README.
  - The badge links directly to the generated HTML coverage report.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->