### PR TITLE
fix: close the four /rhiza:quality findings (#511-#514)

### DIFF
--- a/book/marimo/notebooks/Experiment1.py
+++ b/book/marimo/notebooks/Experiment1.py
@@ -7,6 +7,13 @@
 #     "polars==1.43.2",
 #     "jquantstats==0.10.0"
 # ]
+#
+# [tool.ty.environment]
+# # ``from preamble import ...`` resolves at runtime via the sys.path.insert in the
+# # setup cell below. ty analyses a PEP 723 script in isolation from the project, so
+# # pyproject.toml's [tool.ty.environment] never reaches this file and the path has
+# # to be declared here. Preserve this table if marimo rewrites the header.
+# extra-paths = ["."]
 # ///
 
 """Experiment 1: Basic CTA strategy implementation using moving averages.

--- a/book/marimo/notebooks/Experiment2.py
+++ b/book/marimo/notebooks/Experiment2.py
@@ -7,6 +7,13 @@
 #     "polars==1.43.2",
 #     "jquantstats==0.10.0"
 # ]
+#
+# [tool.ty.environment]
+# # ``from preamble import ...`` resolves at runtime via the sys.path.insert in the
+# # setup cell below. ty analyses a PEP 723 script in isolation from the project, so
+# # pyproject.toml's [tool.ty.environment] never reaches this file and the path has
+# # to be declared here. Preserve this table if marimo rewrites the header.
+# extra-paths = ["."]
 # ///
 
 """Experiment 2: Improved CTA strategy with volatility scaling.

--- a/book/marimo/notebooks/Experiment3.py
+++ b/book/marimo/notebooks/Experiment3.py
@@ -8,6 +8,13 @@
 #     "jquantstats==0.10.0",
 #     "tinycta==0.14.0"
 # ]
+#
+# [tool.ty.environment]
+# # ``from preamble import ...`` resolves at runtime via the sys.path.insert in the
+# # setup cell below. ty analyses a PEP 723 script in isolation from the project, so
+# # pyproject.toml's [tool.ty.environment] never reaches this file and the path has
+# # to be declared here. Preserve this table if marimo rewrites the header.
+# extra-paths = ["."]
 # ///
 
 """Experiment 3: Advanced CTA strategy with price filtering and oscillators.

--- a/book/marimo/notebooks/Experiment4.py
+++ b/book/marimo/notebooks/Experiment4.py
@@ -8,6 +8,13 @@
 #     "jquantstats==0.10.0",
 #     "tinycta==0.14.0"
 # ]
+#
+# [tool.ty.environment]
+# # ``from preamble import ...`` resolves at runtime via the sys.path.insert in the
+# # setup cell below. ty analyses a PEP 723 script in isolation from the project, so
+# # pyproject.toml's [tool.ty.environment] never reaches this file and the path has
+# # to be declared here. Preserve this table if marimo rewrites the header.
+# extra-paths = ["."]
 # ///
 
 """Experiment 4: CTA strategy with optimization and risk scaling.

--- a/book/marimo/notebooks/Experiment5.py
+++ b/book/marimo/notebooks/Experiment5.py
@@ -8,6 +8,13 @@
 #     "jquantstats==0.10.0",
 #     "tinycta==0.14.0"
 # ]
+#
+# [tool.ty.environment]
+# # ``from preamble import ...`` resolves at runtime via the sys.path.insert in the
+# # setup cell below. ty analyses a PEP 723 script in isolation from the project, so
+# # pyproject.toml's [tool.ty.environment] never reaches this file and the path has
+# # to be declared here. Preserve this table if marimo rewrites the header.
+# extra-paths = ["."]
 # ///
 
 """Experiment 5: Advanced CTA strategy with correlation-based optimization.

--- a/book/marimo/notebooks/optimize.py
+++ b/book/marimo/notebooks/optimize.py
@@ -169,7 +169,18 @@ def _portfolio_from_matrix(pos_np: np.ndarray) -> Portfolio:
 # Optuna search spaces. Ranges mirror the marimo sliders (4..192 step 4); ``clip`` is
 # fixed at ``CLIP``; ``slow`` is drawn strictly above ``fast`` so the oscillator holds.
 def _suggest_fast_slow(trial: optuna.Trial) -> tuple[int, int]:
-    """Sample a (fast, slow) pair with slow strictly above fast."""
+    """Sample a (fast, slow) pair with slow strictly above fast.
+
+    ``slow`` is drawn from ``fast + 4`` upwards rather than from a fixed low, so the
+    oscillator can never be handed an inverted pair. Feeding a fixed trial shows the
+    pair coming back in order:
+
+        >>> fast, slow = _suggest_fast_slow(optuna.trial.FixedTrial({"fast": 32, "slow": 96}))
+        >>> (fast, slow)
+        (32, 96)
+        >>> slow > fast
+        True
+    """
     fast = trial.suggest_int("fast", 4, 96, step=4)
     slow = trial.suggest_int("slow", fast + 4, 192, step=4)
     return fast, slow
@@ -212,7 +223,20 @@ def objective_exp5(trial: optuna.Trial) -> float:
 
 # Experiment registry.
 class Experiment:
-    """Bundles an objective with its baseline (notebook default) for reporting."""
+    """Bundles an objective with its baseline (notebook default) for reporting.
+
+    The five experiments are registered in :data:`EXPERIMENTS` under the same keys
+    ``--experiment`` accepts, and each carries the parameters its notebook's sliders
+    default to — the values :meth:`default_sharpe` scores to produce the baseline the
+    search is measured against:
+
+        >>> sorted(EXPERIMENTS)
+        ['1', '2', '3', '4', '5']
+        >>> EXPERIMENTS["1"].name
+        'Experiment 1'
+        >>> EXPERIMENTS["1"].default_params
+        {'fast': 32, 'slow': 96}
+    """
 
     def __init__(
         self, name: str, objective: Callable[..., Any], default_params: dict[str, Any], baseline: Callable[..., Any]

--- a/book/marimo/notebooks/preamble.py
+++ b/book/marimo/notebooks/preamble.py
@@ -30,12 +30,33 @@ def load_notebook(name: str) -> dict[str, Any]:
     The returned dict maps top-level names defined by the notebook to their
     values, so callers can pull out the signal function with
     ``load_notebook("Experiment1.py")["f"]``.
+
+    Executing this module itself is the cheapest demonstration of that contract —
+    the shared helpers come back as ordinary entries in the namespace:
+
+        >>> namespace = load_notebook("preamble.py")
+        >>> sorted(name for name in namespace if name in {"date_col", "load_prices"})
+        ['date_col', 'load_prices']
     """
     return runpy.run_path(str(NOTEBOOK_DIR / name))
 
 
 def load_prices(notebook_file: str) -> pl.DataFrame:
-    """Load and preprocess prices from the standard CSV file."""
+    """Load and preprocess prices from the standard CSV file.
+
+    ``notebook_file`` is the *caller's* own path — the notebooks pass ``__file__`` —
+    and the CSV is read from its ``public/`` sibling directory. The frame comes back
+    with the date column first as nanosecond datetimes, every remaining column (one
+    per asset) cast to ``Float64``, and gaps interpolated:
+
+        >>> prices = load_prices(str(NOTEBOOK_DIR / "preamble.py"))
+        >>> prices.columns[0]
+        'date'
+        >>> prices[date_col].dtype
+        Datetime(time_unit='ns', time_zone=None)
+        >>> set(prices.drop(date_col).dtypes) == {pl.Float64}
+        True
+    """
     path = Path(notebook_file).parent / "public" / "Prices_hashed.csv"
     dframe = pl.read_csv(str(path), try_parse_dates=True)
     dframe = dframe.with_columns(pl.col(date_col).cast(pl.Datetime("ns")))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,22 @@ Repository = "https://github.com/tschm/cs"
 [tool.uv]
 index-strategy = "unsafe-best-match"
 
+[tool.bumpversion]
+# Without a table in a file bump-my-version actually discovers (.bumpversion.toml,
+# .bumpversion.cfg, setup.cfg, pyproject.toml) the tool does not fail — it falls back
+# to `git describe` and reports the last reachable tag as the current version, so a
+# release can be cut at a version that has already been published.
+#
+# No `current_version` here on purpose: bump-my-version reads and rewrites PEP 621
+# [project].version natively, so the version string stays declared in exactly one
+# place and cannot go stale.
+allow_dirty = false
+# The release flow commits and tags itself, so the generated changelog lands in the
+# same commit as the version bump. A bare `bump-my-version bump` would otherwise add
+# a second commit and a duplicate tag.
+commit = false
+tag = false
+
 [tool.deptry]
 package_module_name_map = { marimo = "marimo", numpy = "numpy", polars = "polars", plotly = "plotly" }
 
@@ -98,6 +114,22 @@ exclude_also = [
 # generated structure, not API, so they are exempt from docstring coverage.
 ignore-regex = ["^_$"]
 fail-under = 100
+
+[tool.check_test_layout]
+# This project has no ``src/`` tree: its source is the marimo notebook set under
+# book/marimo/notebooks, and tests/ mirrors *those*. Pointed at the default src/,
+# the generic parity checker reports every test as an orphan; pointed at the real
+# root it still flags the two deviations this project makes deliberately — the
+# cross-cutting integration test (test_notebook_sharpe.py drives all five notebooks
+# end-to-end, so it mirrors no single module) and the use of plain pytest functions
+# rather than mirrored ``Test*`` classes, which is idiomatic pytest.
+#
+# Parity is therefore enforced by the repo-local gate scripts/check_test_layout.py,
+# wired in as the "Tests mirror the marimo notebooks 1:1" pre-commit hook, which
+# understands the actual layout. Per-module coverage is guaranteed independently by
+# the 100% line-and-branch coverage gate in [tool.coverage] / make test.
+enforce = false
+reason = "No src/ tree — source is the marimo notebooks under book/marimo/notebooks. Parity is enforced by scripts/check_test_layout.py (pre-commit hook 'Tests mirror the marimo notebooks 1:1'); per-module coverage is guaranteed by the 100% coverage gate."
 
 [dependency-groups]
 test = [

--- a/scripts/check_test_layout.py
+++ b/scripts/check_test_layout.py
@@ -46,8 +46,10 @@ NOTEBOOK_DIR = ROOT / "book" / "marimo" / "notebooks"
 TESTS_DIR = ROOT / "tests"
 
 # Test files that legitimately have no single source module: cross-cutting
-# integration tests that drive several notebooks at once.
-INTEGRATION_TESTS = {"test_notebook_sharpe.py"}
+# tests that drive several source modules at once. ``test_notebook_sharpe.py``
+# executes every experiment notebook end-to-end; ``test_doctests.py`` runs the
+# doctest examples of every hand-written module.
+INTEGRATION_TESTS = {"test_notebook_sharpe.py", "test_doctests.py"}
 
 # Test files that flow down from the rhiza template (SYNC action) and therefore
 # mirror no notebook of this project.

--- a/tests/test_doctests.py
+++ b/tests/test_doctests.py
@@ -1,0 +1,58 @@
+"""Execute the doctest examples embedded in the hand-written notebook modules.
+
+Why this test exists
+--------------------
+``make docs-coverage`` (interrogate) asks whether a docstring *exists*; until this
+module, nothing in the repo asked whether what a docstring *claims* is still true.
+That is the documentation failure with the longest half-life: an example whose
+output has drifted keeps rendering perfectly and keeps passing every other gate,
+and the person who finds out is a newcomer following the README.
+
+The template's own docstring gate does not close the gap here. ``.rhiza/tests/
+test_docstrings.py`` looks for a ``src/`` tree, and this project has none — its
+source is the marimo notebook set under ``book/marimo/notebooks`` — so it skips
+outright rather than checking anything.
+
+Scope
+-----
+Only the two hand-written modules. ``preamble.py`` and ``optimize.py`` are ordinary
+Python whose docstrings are durable. The ``Experiment*.py`` notebooks are
+marimo-generated, and the reasoning that exempts their generated cell scaffolding
+from ``[tool.mypy]`` applies equally to examples embedded in them: marimo would wipe
+them on the next rewrite, so they buy no lasting safety. Those notebooks are pinned
+end-to-end by ``test_notebook_sharpe.py`` instead.
+
+``conftest.py`` puts the notebook directory on ``sys.path``, so both modules import
+here exactly as they do for every other test in this suite.
+"""
+
+import doctest
+from types import ModuleType
+
+import optimize
+import preamble
+import pytest
+
+MODULES = [preamble, optimize]
+
+
+@pytest.mark.parametrize("module", MODULES, ids=lambda module: module.__name__)
+def test_docstring_examples_produce_their_documented_output(module: ModuleType) -> None:
+    """Every ``>>>`` example in the module runs and returns what it says it returns."""
+    results = doctest.testmod(module, verbose=False)
+    assert results.failed == 0, (
+        f"{results.failed} of {results.attempted} doctest example(s) failed in "
+        f"{module.__name__}; see the diff printed above"
+    )
+
+
+@pytest.mark.parametrize("module", MODULES, ids=lambda module: module.__name__)
+def test_module_actually_carries_examples(module: ModuleType) -> None:
+    """Guard against a vacuous pass: a module with no examples must not look green.
+
+    ``doctest.testmod`` reports success on a module containing nothing to run, so
+    without this assertion the gate above would silently stop meaning anything the
+    moment an example was deleted.
+    """
+    found = sum(len(test.examples) for test in doctest.DocTestFinder().find(module))
+    assert found > 0, f"{module.__name__} carries no doctest examples"


### PR DESCRIPTION
Closes the four findings from the `/rhiza:quality` run on template v1.3.3. No behaviour changes — the pinned Sharpe regressions and the 100% line-and-branch coverage gate are untouched.

## What changed

### #511 — `[tool.bumpversion]` (`pyproject.toml`)

No bumpversion config existed in any of the four files `bump-my-version` discovers, so it fell back to `git describe` and reported the last reachable tag as the current version — meaning a release could be cut at a version already published. The failure was invisible until it bit.

Adds the minimum workable table: `commit`/`tag` false (the release flow commits and tags itself, so the changelog lands in the bump commit) and deliberately **no** `current_version`, so the version stays declared once in `[project].version` and cannot go stale.

`make rhiza-test`: `1 failed, 36 passed, 3 skipped` → **39 passed**. Two of those skips were gated behind this failure, so fixing it also activated the "config does not duplicate the version" and "release flow owns the commit and the tag" checks.

### #513 — ty configuration (5 notebook headers)

`make typecheck` runs two checkers. `mypy --strict` was clean; `ty` reported 5 × `unresolved-import: Cannot resolve imported module 'preamble'` and every notebook failed at the import, so ty never reached the code below it.

**The issue's proposed fix does not work, and the reason is worth recording.** `[tool.ty.environment] extra-paths` in `pyproject.toml` is the correct key — ty's debug log confirms it reads it (`Adding extra search-path .../book/marimo/notebooks`) — but it has no effect here. `Experiment1-5.py` are **PEP 723 inline scripts**, and ty analyses those in isolation from the project, rebuilding settings per file from the inline metadata. That is why the diagnostic listed only stdlib and site-packages, with no first-party path at all. It is also exactly why the 5 failing files are the 5 notebooks with a `# /// script` header, while `optimize.py` and `preamble.py` — which import `preamble` the same way — always resolved fine.

ty *does* read `[tool.ty]` from the inline metadata block, so `extra-paths` is now declared in each notebook header, where it applies. Verified against a control: an identical file without the block still fails.

Two alternatives were rejected:

- `[tool.ty.src] exclude-scripts = true` makes the gate pass by **excluding the five notebooks from checking** (files checked drops 7 → 2). That is a green light bought by measuring less.
- `[tool.ty.analysis] allowed-unresolved-imports` does not reach the scripts either, for the same isolation reason.

The project-level `[tool.ty.environment]` block was dropped after testing showed it unnecessary — keeping config that provably does nothing is cargo-cult.

`make typecheck` now reports `All checks passed!` **and** `no issues found in 7 source files`, with all 7 files still in scope.

> ⚠️ These blocks live in marimo-generated headers. Each carries an inline comment asking that the table be preserved, because if a regeneration drops it, ty goes quiet rather than failing loudly.

### #514 — `[tool.check_test_layout]` (`pyproject.toml`)

The test layout is deliberate and already well documented in `scripts/check_test_layout.py`, but only in prose, so any generic parity checker false-failed it: pointed at the default `src/` it called all 8 test files orphans, and pointed at the real source root it still flagged the two intentional deviations (`test_notebook_sharpe.py` drives all five notebooks end-to-end so it mirrors no single module; classes are exercised through plain pytest functions rather than mirrored `Test*` classes).

Declares the opt-out with the required `reason`. The repo-local gate that does the real enforcing is unchanged and still passes.

### #512 — executable documentation

There were **0 doctest examples** across 7 modules. Docstring *coverage* was already a perfect 194/194 against a `fail-under = 100` threshold — but coverage only asks whether a docstring exists, never whether it is still true. Nothing closed that gap: the template's own `.rhiza/tests/test_docstrings.py` skips outright here, because it looks for a `src/` tree this project does not have.

Adds 12 examples to the two hand-written modules — `preamble.load_prices`, `preamble.load_notebook`, `optimize.Experiment` and `optimize._suggest_fast_slow` — each output verified by running it before it was written down.

Adds `tests/test_doctests.py` to execute them, because examples nothing runs are precisely what rots. It asserts both that the examples pass **and** that the modules still carry some; without the second check the gate would silently go vacuous the moment an example was deleted. This needed one line in `scripts/check_test_layout.py` to allow-list the new cross-cutting test.

The marimo-generated `Experiment*.py` notebooks are deliberately excluded, on the same reasoning already recorded in `[tool.mypy]` for their generated cell scaffolding: marimo would wipe the examples on the next rewrite, so they buy no lasting safety. Their behaviour stays pinned end-to-end by `test_notebook_sharpe.py`.

## Verification

Every gate was run locally, before and after:

| Gate | Before | After |
| --- | --- | --- |
| `make fmt` | PASS | PASS (23 hooks, nothing rewritten) |
| `make typecheck` | PASS, ty blind (5 errors swallowed) | **PASS, both checkers clean** |
| `make docs-coverage` | 100% (194/194) | 100% (197/197) |
| `make deptry` | PASS | PASS |
| `make security` | PASS | PASS |
| `make rhiza-test` | **FAIL** (1/40) | **39 passed** |
| `make test` | 76 passed, 100% cov | **80 passed**, 100% line+branch |
| `make marimo-validate` | — | all 7 notebooks valid |
| Test-layout parity | false-fail | PASS (declared opt-out) |
| Doc examples (`--run`) | 0 examples | **12 attempted, 0 failed, 0 unimportable** |

`make marimo-validate` was run specifically because this PR edits the PEP 723 headers, which marimo owns.

## Upstream, not fixed here

Two Rhiza-owned issues surfaced during this work and belong in `jebel-quant/rhiza` rather than this repo:

1. **`.rhiza/make.d/python.mk:258-263` discards ty's exit code.** In `TYPECHECKER=both` the recipe is `ty check … && printf …; mypy --strict …` — the `&&` binds to the `printf`, and the `;` then runs mypy unconditionally, so the target's exit status is mypy's alone. This is how 5 ty errors sat in a passing gate, and it likely hides ty results in **every** consumer repo. The most consequential of the two.
2. **`.rhiza/tests/test_docstrings.py` hardcodes `src/`** and skips silently on any other source root — a skip that reads as green. It still skips on this branch; `tests/test_doctests.py` now covers the substance locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded notebook helper documentation with usage examples and details on loading, data conversion, interpolation, and optimization behavior.
* **Testing**
  * Added doctest coverage to verify documented examples execute successfully and remain present.
  * Updated test-layout documentation to include doctest integration coverage.
* **Developer Experience**
  * Improved notebook static-analysis support by configuring local module resolution.
  * Added project configuration for version updates and the repository’s notebook-oriented test structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->