### PR TITLE
fix: close the four /rhiza:quality findings (#516-#519)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,6 +44,34 @@ repos:
         pass_filenames: false
         files: '^(book/marimo/notebooks/.*\.py|tests/.*\.py)$'
 
+      # `make typecheck` runs mypy over ${SOURCE_FOLDER} only, and rhiza's recipe
+      # guards that with `[ -d "${SOURCE_FOLDER}" ]` — a single-directory test, so
+      # scripts/ cannot be appended to it. Passing paths on the command line also
+      # overrides [tool.mypy] files, so declaring them there would not help either.
+      # This hook is what holds the gate scripts to the same --strict bar as the
+      # notebooks (issue #516). Settings still come from [tool.mypy].
+      - id: mypy-scripts
+        name: mypy --strict over scripts/
+        entry: uv run --with mypy mypy --strict scripts
+        language: system
+        pass_filenames: false
+        files: '^scripts/.*\.py$'
+
+      # Coverage for the gate scripts, for the same reason as the hook above:
+      # `make test` passes --cov=${SOURCE_FOLDER}, which *replaces* the source
+      # list in [tool.coverage.run], so scripts/ cannot be folded into the main
+      # coverage gate. This runs their unit tests under their own 100% bar.
+      - id: pytest-scripts-coverage
+        name: scripts/ unit tests at 100% coverage
+        entry: >-
+          uv run --with pytest --with pytest-cov --with pytest-timeout
+          pytest tests/test_check_test_layout.py tests/test_check_inline_pins.py
+          --cov=scripts --cov-branch --cov-fail-under=100
+          --cov-report=term-missing -q -p no:cacheprovider
+        language: system
+        pass_filenames: false
+        files: '^(scripts/.*\.py|tests/test_check_.*\.py)$'
+
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: 'v0.16.2'
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,10 +50,18 @@ repos:
       # overrides [tool.mypy] files, so declaring them there would not help either.
       # This hook is what holds the gate scripts to the same --strict bar as the
       # notebooks (issue #516). Settings still come from [tool.mypy].
+      #
+      # `language: python` rather than `system`: the hooks above shell out to
+      # `python3`, which every runner has, but uv is installed into the repo's own
+      # bin/ by the make bootstrap and is not on PATH for a hook subprocess in CI.
+      # Letting prek provision the environment keeps the hook independent of how
+      # the caller was set up. Versions are pinned so a hook run is reproducible;
+      # Renovate bumps them like any other pinned rev in this file.
       - id: mypy-scripts
         name: mypy --strict over scripts/
-        entry: uv run --with mypy mypy --strict scripts
-        language: system
+        entry: mypy --strict scripts
+        language: python
+        additional_dependencies: ["mypy==2.3.1"]
         pass_filenames: false
         files: '^scripts/.*\.py$'
 
@@ -61,14 +69,18 @@ repos:
       # `make test` passes --cov=${SOURCE_FOLDER}, which *replaces* the source
       # list in [tool.coverage.run], so scripts/ cannot be folded into the main
       # coverage gate. This runs their unit tests under their own 100% bar.
+      # pytest-timeout is required because pytest.ini sets `timeout = 60`.
       - id: pytest-scripts-coverage
         name: scripts/ unit tests at 100% coverage
         entry: >-
-          uv run --with pytest --with pytest-cov --with pytest-timeout
           pytest tests/test_check_test_layout.py tests/test_check_inline_pins.py
           --cov=scripts --cov-branch --cov-fail-under=100
           --cov-report=term-missing -q -p no:cacheprovider
-        language: system
+        language: python
+        additional_dependencies:
+          - "pytest==9.1.1"
+          - "pytest-cov==7.1.0"
+          - "pytest-timeout==2.4.0"
         pass_filenames: false
         files: '^(scripts/.*\.py|tests/test_check_.*\.py)$'
 

--- a/.rhiza/.env
+++ b/.rhiza/.env
@@ -9,8 +9,12 @@
 # Variables defined here are exported to all Make recipes.
 
 # This repository is a marimo "book": notebooks live under book/marimo/notebooks,
-# not the template default docs/notebooks. (SOURCE_FOLDER is further pinned in
-# .rhiza/make.d/custom-env.mk, which is locally owned and applied after this file.)
+# not the template default docs/notebooks.
+#
+# SOURCE_FOLDER is deliberately NOT set here. It is declared once, in
+# .rhiza/make.d/custom-env.mk, which is locally owned and applied *after* this
+# file — so any value written here would be silently overridden. Declaring it in
+# both places (as this file used to, with the dead template default `src`) means
+# the more obvious of the two locations states the wrong answer.
 MARIMO_FOLDER=book/marimo/notebooks
-SOURCE_FOLDER=src
 RHIZA_CI_OS_MATRIX=["ubuntu-latest","macos-latest","windows-latest"]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,7 +11,10 @@ nav:
   - Home: index.md
   - Development:
       - Marimo: development/MARIMO.md
+      - Optimization: development/OPTIMIZATION.md
       - Sharpe pins: development/SHARPE_PINS.md
+      - Tests: development/TESTS.md
+      - Test layout: development/TEST_LAYOUT.md
   - Notebooks:
       - Experiment1: notebooks/Experiment1.html
       - Experiment2: notebooks/Experiment2.html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,13 @@ patch = ["subprocess"]
 # Scope measurement to the notebooks. The spawn start method re-imports the
 # test module in each child to locate the worker function; without this the
 # child would also report the test file itself.
+#
+# scripts/ is deliberately NOT listed here (issue #516). `make test` passes
+# --cov=${SOURCE_FOLDER}, which replaces this list as coverage's measurement
+# scope, so adding scripts/ here does not get it measured — it only gets it
+# *reported*, at 0%, which fails the 100% gate for a purely cosmetic reason.
+# The gate scripts are held to their own 100% bar by the
+# "scripts/ unit tests at 100% coverage" pre-commit hook instead.
 source = ["book/marimo/notebooks"]
 
 [tool.coverage.report]
@@ -127,9 +134,9 @@ fail-under = 100
 # Parity is therefore enforced by the repo-local gate scripts/check_test_layout.py,
 # wired in as the "Tests mirror the marimo notebooks 1:1" pre-commit hook, which
 # understands the actual layout. Per-module coverage is guaranteed independently by
-# the 100% line-and-branch coverage gate in [tool.coverage] / make test.
+# the full line-and-branch coverage gate in [tool.coverage] / make test.
 enforce = false
-reason = "No src/ tree — source is the marimo notebooks under book/marimo/notebooks. Parity is enforced by scripts/check_test_layout.py (pre-commit hook 'Tests mirror the marimo notebooks 1:1'); per-module coverage is guaranteed by the 100% coverage gate."
+reason = "No src/ tree — source is the marimo notebooks under book/marimo/notebooks. Parity is enforced by scripts/check_test_layout.py (pre-commit hook 'Tests mirror the marimo notebooks 1:1'); per-module coverage is guaranteed by the full coverage gate."
 
 [dependency-groups]
 test = [

--- a/scripts/check_inline_pins.py
+++ b/scripts/check_inline_pins.py
@@ -40,7 +40,13 @@ def header_pins(notebook: Path) -> dict[str, str]:
     """Return {package: version} for the ``name==version`` pins in a notebook header."""
     pins: dict[str, str] = {}
     for line in notebook.read_text().splitlines():
-        if line.strip() == HEADER_END and pins:
+        # Stop at the PEP 723 terminator unconditionally. The opening fence is
+        # ``# /// script``, which never equals HEADER_END, so the first bare
+        # ``# ///`` is always the end of the header. Guarding this break on
+        # having already found a pin would let a header that declares none fall
+        # through and scan the whole file body, collecting any later
+        # pin-shaped comment as though it came from the header.
+        if line.strip() == HEADER_END:
             break
         match = PIN_PATTERN.match(line.strip())
         if match:

--- a/scripts/check_test_layout.py
+++ b/scripts/check_test_layout.py
@@ -55,7 +55,15 @@ INTEGRATION_TESTS = {"test_notebook_sharpe.py", "test_doctests.py"}
 # mirror no notebook of this project.
 TEMPLATE_TESTS = {"test_rhiza_packaging.py"}
 
-_EXEMPT = INTEGRATION_TESTS | TEMPLATE_TESTS
+# Tests for this folder's own gate scripts. They mirror ``scripts/<name>.py``
+# rather than a notebook, so the reverse check below would otherwise report them
+# as orphans — which is what kept these two scripts untested (issue #516): the
+# layout gate structurally forbade its own test. Kept as an explicit named set
+# rather than a blanket "anything matching a scripts/ module" rule, so adding a
+# script still requires a deliberate decision about whether it needs a test.
+SCRIPT_TESTS = {"test_check_test_layout.py", "test_check_inline_pins.py"}
+
+_EXEMPT = INTEGRATION_TESTS | TEMPLATE_TESTS | SCRIPT_TESTS
 
 # Non-test helper modules under tests/ (imported by the tests, not test files
 # themselves). ``test_*.py`` globbing already excludes these; listed for clarity.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,12 @@ NOTEBOOK_DIR = (Path(__file__).resolve().parents[1] / "book" / "marimo" / "noteb
 if str(NOTEBOOK_DIR) not in sys.path:
     sys.path.insert(0, str(NOTEBOOK_DIR))
 
+# The repo-local gate scripts are standalone stdlib modules, not a package, so
+# they need the same treatment to be importable by their unit tests.
+SCRIPTS_DIR = (Path(__file__).resolve().parents[1] / "scripts").resolve()
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
 N = 600  # satisfies min_samples=300 (the highest requirement across all experiments)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,6 @@ Security Notes:
 import sys
 from pathlib import Path
 
-import polars as pl
 import pytest
 
 # Bootstrap the notebook directory onto sys.path once, here, so every test
@@ -29,13 +28,25 @@ if str(SCRIPTS_DIR) not in sys.path:
 N = 600  # satisfies min_samples=300 (the highest requirement across all experiments)
 
 
+# polars is imported inside the fixtures rather than at module level so this
+# conftest stays loadable in an environment that has only pytest. The gate-script
+# tests (tests/test_check_*.py) exercise stdlib-only modules and run in exactly
+# such an environment — the "scripts/ unit tests at 100% coverage" pre-commit
+# hook, which prek provisions with pytest alone. A module-level import would make
+# collecting them require the whole scientific stack, purely to reach the
+# sys.path bootstrap above. Every fixture below is requested only by tests that
+# already depend on polars, so the import always resolves where it is used.
 @pytest.fixture
 def rising():
     """Return a DataFrame with a monotonically rising price series."""
+    import polars as pl
+
     return pl.DataFrame({"p": [float(i) for i in range(1, N + 1)]})
 
 
 @pytest.fixture
 def falling():
     """Return a DataFrame with a monotonically falling price series."""
+    import polars as pl
+
     return pl.DataFrame({"p": [float(i) for i in range(N, 0, -1)]})

--- a/tests/test_check_inline_pins.py
+++ b/tests/test_check_inline_pins.py
@@ -1,0 +1,142 @@
+"""Unit tests for the repo-local PEP 723 inline-pin gate.
+
+Why these exist
+---------------
+``scripts/check_inline_pins.py`` guarantees that the ``# /// script`` pins in the
+marimo notebooks agree with ``uv.lock``. It runs as a pre-commit hook, so it
+*executes* on every relevant commit — but until this module nothing verified that
+it still *detects* anything. A glob that stopped matching, or a regex that stopped
+firing, would leave the hook passing silently while the guarantee was gone.
+
+The Sharpe-ratio regression tests pin results to 1e-6, and they only mean anything
+if the notebook environment and the locked environment agree. That makes a silent
+failure of this gate expensive, which is why it gets tests of its own.
+
+Every test drives the module through monkeypatched ``ROOT`` / ``NOTEBOOK_DIR``
+globals against a temporary tree, so nothing here depends on the repository's real
+notebooks or lockfile.
+"""
+
+from pathlib import Path
+
+import check_inline_pins
+import pytest
+
+HEADER = """\
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "numpy=={numpy}",
+#     "polars=={polars}",
+# ]
+# ///
+
+\"\"\"A notebook.\"\"\"
+"""
+
+
+def _write_lock(root: Path, packages: dict[str, str]) -> None:
+    """Write a minimal uv.lock carrying ``packages`` into ``root``."""
+    entries = "\n".join(f'[[package]]\nname = "{name}"\nversion = "{version}"\n' for name, version in packages.items())
+    (root / "uv.lock").write_text(entries)
+
+
+def _write_notebook(directory: Path, name: str, body: str) -> Path:
+    """Write ``body`` to ``directory/name`` and return the path."""
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / name
+    path.write_text(body)
+    return path
+
+
+@pytest.fixture
+def tree(tmp_path, monkeypatch):
+    """Point the module at a temporary root/notebook directory pair."""
+    notebooks = tmp_path / "book" / "marimo" / "notebooks"
+    notebooks.mkdir(parents=True)
+    monkeypatch.setattr(check_inline_pins, "ROOT", tmp_path)
+    monkeypatch.setattr(check_inline_pins, "NOTEBOOK_DIR", notebooks)
+    return tmp_path, notebooks
+
+
+def test_locked_versions_reads_every_package(tree):
+    """locked_versions returns one lowercased entry per package in uv.lock."""
+    root, _ = tree
+    _write_lock(root, {"NumPy": "2.4.6", "polars": "1.43.2"})
+
+    assert check_inline_pins.locked_versions() == {"numpy": "2.4.6", "polars": "1.43.2"}
+
+
+def test_header_pins_reads_the_declared_pins(tree):
+    """Each ``name==version`` line in the PEP 723 header is returned."""
+    _, notebooks = tree
+    notebook = _write_notebook(notebooks, "Experiment1.py", HEADER.format(numpy="2.4.6", polars="1.43.2"))
+
+    assert check_inline_pins.header_pins(notebook) == {"numpy": "2.4.6", "polars": "1.43.2"}
+
+
+def test_header_pins_stops_at_the_terminator(tree):
+    """A pin-shaped comment in the file *body* is not mistaken for a header pin.
+
+    This is the regression test for issue #518. The scan used to break at the
+    ``# ///`` terminator only once it had already collected a pin, so a header
+    declaring none fell through and kept reading the rest of the file.
+    """
+    _, notebooks = tree
+    body = '# /// script\n# requires-python = ">=3.12"\n# ///\n\n# "numpy==9.9.9"\n'
+    notebook = _write_notebook(notebooks, "Experiment1.py", body)
+
+    assert check_inline_pins.header_pins(notebook) == {}
+
+
+def test_notebook_drift_is_empty_when_pins_agree(tree):
+    """A notebook whose pins match the lock produces no drift messages."""
+    _, notebooks = tree
+    notebook = _write_notebook(notebooks, "Experiment1.py", HEADER.format(numpy="2.4.6", polars="1.43.2"))
+
+    assert check_inline_pins.notebook_drift(notebook, {"numpy": "2.4.6", "polars": "1.43.2"}) == []
+
+
+def test_notebook_drift_reports_a_version_mismatch(tree):
+    """A pin disagreeing with the lock is reported with both versions."""
+    _, notebooks = tree
+    notebook = _write_notebook(notebooks, "Experiment1.py", HEADER.format(numpy="2.4.6", polars="1.43.2"))
+
+    messages = check_inline_pins.notebook_drift(notebook, {"numpy": "2.0.0", "polars": "1.43.2"})
+
+    assert len(messages) == 1
+    assert "numpy==2.4.6 (inline)" in messages[0]
+    assert "numpy==2.0.0 (uv.lock)" in messages[0]
+
+
+def test_notebook_drift_reports_a_package_absent_from_the_lock(tree):
+    """A pin naming a package the lock does not resolve is reported."""
+    _, notebooks = tree
+    notebook = _write_notebook(notebooks, "Experiment1.py", HEADER.format(numpy="2.4.6", polars="1.43.2"))
+
+    messages = check_inline_pins.notebook_drift(notebook, {"numpy": "2.4.6"})
+
+    assert len(messages) == 1
+    assert "'polars' is pinned inline but absent from uv.lock" in messages[0]
+
+
+def test_main_returns_zero_when_every_pin_agrees(tree):
+    """Exit code 0 when no notebook has drifted."""
+    root, notebooks = tree
+    _write_lock(root, {"numpy": "2.4.6", "polars": "1.43.2"})
+    _write_notebook(notebooks, "Experiment1.py", HEADER.format(numpy="2.4.6", polars="1.43.2"))
+
+    assert check_inline_pins.main() == 0
+
+
+def test_main_returns_one_and_names_the_drift(tree, capsys):
+    """Exit code 1, naming the offending notebook and the fix."""
+    root, notebooks = tree
+    _write_lock(root, {"numpy": "2.4.6", "polars": "1.43.2"})
+    _write_notebook(notebooks, "Experiment3.py", HEADER.format(numpy="1.0.0", polars="1.43.2"))
+
+    assert check_inline_pins.main() == 1
+
+    stderr = capsys.readouterr().err
+    assert "Experiment3.py" in stderr
+    assert "Update the '# /// script' headers to match uv.lock." in stderr

--- a/tests/test_check_test_layout.py
+++ b/tests/test_check_test_layout.py
@@ -1,0 +1,124 @@
+"""Unit tests for the repo-local test-layout parity gate.
+
+Why these exist
+---------------
+``scripts/check_test_layout.py`` is the reason this project can set
+``enforce = false`` on the generic ``[tool.check_test_layout]`` checker: it is the
+gate that actually understands the notebook layout. It runs as a pre-commit hook,
+but until this module nothing verified that it still *detects* a violation. A
+gate that silently stops failing is worse than no gate, because the opt-out in
+``pyproject.toml`` points at it as the compensating control.
+
+Note the bootstrapping problem this module had to solve first (issue #516): the
+checker's own reverse pass treats any ``tests/test_<x>.py`` without a matching
+notebook ``<x>.py`` as an orphan, so this very file was a violation until it was
+added to ``SCRIPT_TESTS``.
+
+Every test drives the module through monkeypatched ``ROOT`` / ``NOTEBOOK_DIR`` /
+``TESTS_DIR`` globals against a temporary tree.
+"""
+
+import check_test_layout
+import pytest
+
+
+@pytest.fixture
+def tree(tmp_path, monkeypatch):
+    """Point the module at an empty temporary notebook/tests directory pair."""
+    notebooks = tmp_path / "book" / "marimo" / "notebooks"
+    tests = tmp_path / "tests"
+    notebooks.mkdir(parents=True)
+    tests.mkdir()
+    monkeypatch.setattr(check_test_layout, "ROOT", tmp_path)
+    monkeypatch.setattr(check_test_layout, "NOTEBOOK_DIR", notebooks)
+    monkeypatch.setattr(check_test_layout, "TESTS_DIR", tests)
+    return notebooks, tests
+
+
+def test_mirrored_layout_is_clean(tree):
+    """A notebook with its matching test file produces no violations."""
+    notebooks, tests = tree
+    (notebooks / "Experiment1.py").write_text("")
+    (tests / "test_experiment1.py").write_text("")
+
+    assert check_test_layout.check() == []
+
+
+def test_missing_mirror_test_is_reported(tree):
+    """A notebook with no ``test_<name>.py`` is a violation."""
+    notebooks, _ = tree
+    (notebooks / "Experiment1.py").write_text("")
+
+    errors = check_test_layout.check()
+
+    assert len(errors) == 1
+    assert "missing test file tests/test_experiment1.py" in errors[0]
+
+
+def test_orphan_test_file_is_reported(tree):
+    """A test file mapping to no notebook is a violation."""
+    _, tests = tree
+    (tests / "test_nothing.py").write_text("")
+
+    errors = check_test_layout.check()
+
+    assert len(errors) == 1
+    assert "orphan test file" in errors[0]
+    assert "test_nothing.py" in errors[0]
+
+
+@pytest.mark.parametrize("exempt", sorted(check_test_layout._EXEMPT))
+def test_exempt_test_files_are_not_orphans(tree, exempt):
+    """Integration, template and script tests mirror no notebook by design."""
+    _, tests = tree
+    (tests / exempt).write_text("")
+
+    assert check_test_layout.check() == []
+
+
+def test_matching_is_case_insensitive(tree):
+    """TitleCased notebooks map to lowercase test names."""
+    notebooks, tests = tree
+    (notebooks / "ExperimentFive.py").write_text("")
+    (tests / "test_experimentfive.py").write_text("")
+
+    assert check_test_layout.check() == []
+
+
+def test_conftest_is_not_treated_as_a_notebook(tree):
+    """``conftest.py`` beside the notebooks needs no mirror test."""
+    notebooks, _ = tree
+    (notebooks / "conftest.py").write_text("")
+
+    assert check_test_layout.check() == []
+
+
+def test_main_returns_zero_and_reports_success(tree, capsys):
+    """Exit code 0 and a success message when the layout is clean."""
+    notebooks, tests = tree
+    (notebooks / "Experiment1.py").write_text("")
+    (tests / "test_experiment1.py").write_text("")
+
+    assert check_test_layout.main() == 0
+    assert "Test layout OK" in capsys.readouterr().out
+
+
+def test_main_returns_one_and_lists_each_violation(tree, capsys):
+    """Exit code 1, printing every violation to stderr."""
+    notebooks, _ = tree
+    (notebooks / "Experiment1.py").write_text("")
+
+    assert check_test_layout.main() == 1
+
+    stderr = capsys.readouterr().err
+    assert "Test-layout check failed:" in stderr
+    assert "test_experiment1.py" in stderr
+
+
+def test_the_real_repository_layout_is_clean():
+    """The gate passes against this repository as committed.
+
+    The tests above run on synthetic trees; this one is the guard that the real
+    notebook/test layout has not drifted, independent of the pre-commit hook.
+    """
+    assert check_test_layout.check() == []


### PR DESCRIPTION
Closes #516
Closes #517
Closes #518
Closes #519

Findings from a `/rhiza:quality` run (full mode, template v1.3.3). All seven
template gates were green before this branch; these are the gaps the gates do not
measure.

## #516 — `scripts/` sat outside type checking and the test suite

`scripts/check_test_layout.py` and `scripts/check_inline_pins.py` are the two
repo-local gates guaranteeing test/notebook parity and PEP 723 pin freshness.
They ran as pre-commit hooks, but nothing verified they still *detected*
anything — a glob that stopped matching would leave both passing silently while
the guarantee was gone. That matters here because the Sharpe regressions pin to
`1e-6`, which only means something if the notebook and locked environments agree.

Adds **21 tests at 100% line and branch coverage** on both scripts, driving them
through monkeypatched module globals against temporary trees.

Two things worth reviewing:

- **The layout gate structurally forbade its own test.** Its reverse pass treats
  any `tests/test_<x>.py` without a matching notebook `<x>.py` as an orphan, so
  `tests/test_check_test_layout.py` was a violation of the very gate it tests.
  Hence `SCRIPT_TESTS`, kept as an explicit named set rather than a blanket
  "anything mirroring a `scripts/` module" rule, so adding a script still forces a
  deliberate decision about whether it needs a test.
- **Both gates are enforced as local pre-commit hooks, not `make` targets.**
  Neither could be widened from config:
  - `make typecheck` guards on `[ -d "${SOURCE_FOLDER}" ]` (`python.mk:242`), a
    single-directory test, and passing paths on the command line overrides
    `[tool.mypy] files` anyway.
  - `make test` passes `--cov=${SOURCE_FOLDER}`, which **replaces** rather than
    extends `[tool.coverage.run] source`. Adding `scripts` there was tried first
    and dropped the gate to 85% — the files get *reported* at 0% without being
    *measured*.

  Both constraints are template-owned; each is documented at the point of
  workaround.

Note the issue body overstated the gap and has a [correction comment](https://github.com/tschm/cs/issues/516#issuecomment-5301776702):
interrogate, bandit and ruff already covered `scripts/` via pre-commit. The real
gaps were type checking and tests.

## #517 — three developer docs were unreachable from the published site

`mkdocs.yml` listed two of the five `docs/development/*.md` files.
`OPTIMIZATION.md` and `TEST_LAYOUT.md` are advertised in the README as the
developer notes; `TESTS.md` is the largest developer document in the repo. All
three built but had no nav entry, so they were reachable on GitHub and invisible
on tschm.github.io/cs.

Verified with a `--strict` build before and after: the same 12 pre-existing
warnings either way (mostly `notebooks/*.html`, which `make book` generates), with
the "pages not included in nav" notice gone. No new warnings introduced.

## #518 — `header_pins()` could read past the PEP 723 header

The scan broke at the `# ///` terminator only once it had already collected a
pin, so a header declaring none fell through and scanned the whole file body,
where any pin-shaped comment would be collected as though it came from the
header. Latent today — all five notebooks carry pins — but the `and pins` guard
read as an accident rather than a decision. Regression test included.

## #519 — dead `SOURCE_FOLDER=src` in `.rhiza/.env`

Overridden by `.rhiza/make.d/custom-env.mk`, which is applied later, so the more
obvious of the two locations stated the wrong answer. `.rhiza/.env` is
template-synced under `strategy: merge`, so a future `/rhiza:update` may
reintroduce it.

## Verification

`fmt` (25 hooks, including the two new ones), `typecheck`, `docs-coverage`
(220/220), `deptry`, `security`, `rhiza-test` (39 passed) and `test` all pass.
Suite is **101 passed, 1 skipped**, up from 80, with the coverage gate still at
100% on 450 statements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notebook dependency-pin validation to stop at the correct section boundary and accurately report mismatches or missing locked packages.
  * Improved test-layout validation to recognize approved exceptions and matching files more reliably.

* **Documentation**
  * Expanded development documentation navigation with optimization, testing, and test-layout guidance.
  * Clarified coverage and test-layout expectations.

* **Quality Improvements**
  * Added automated checks and comprehensive tests to strengthen validation reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->