### PR TITLE
chore: own SECURITY.md and drop its false fuzzing claim

### DIFF
--- a/.rhiza/template.lock
+++ b/.rhiza/template.lock
@@ -4,6 +4,7 @@ host: github
 ref: v1.4.2
 include: []
 exclude:
+- SECURITY.md
 - .github/DISCUSSION_TEMPLATE
 - .github/ISSUE_TEMPLATE
 - .github/CONFIG.md
@@ -36,7 +37,6 @@ files:
 - .rhiza/CONTRIBUTING.md
 - .rhiza/semgrep.yml
 - LICENSE
-- SECURITY.md
 - cliff.toml
 - docs/assets/rhiza-logo.svg
 - docs/development/MARIMO.md

--- a/.rhiza/template.yml
+++ b/.rhiza/template.yml
@@ -10,6 +10,10 @@ templates:
 # Paths the template ships but this repo owns outright. Written as destination
 # paths — where the file lands here, not where it sits in the template.
 exclude:
+  # SECURITY.md makes factual claims about THIS repo's security posture (which scanners,
+  # which release protections). Only the repo knows which are true -- the template shipped a
+  # fuzzing claim that was false here -- so the file is owned here, not template-managed.
+  - SECURITY.md
   - .github/DISCUSSION_TEMPLATE
   - .github/ISSUE_TEMPLATE
   - .github/CONFIG.md

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -61,7 +61,6 @@ This project implements several security measures:
 - **CodeQL**: Automated code scanning for Python and GitHub Actions
 - **Bandit**: Python security linter integrated in CI and pre-commit
 - **Secret Scanning**: GitHub secret scanning enabled on this repository
-- **Fuzzing**: ClusterFuzzLite exercises Atheris-based fuzz targets on pull requests and scheduled batch runs
 
 ### Supply Chain Security
 - **SLSA Provenance**: Build attestations for release artifacts (public repositories only)


### PR DESCRIPTION
## What

- Remove the `- **Fuzzing**: ClusterFuzzLite exercises Atheris-based fuzz targets ...` bullet from `SECURITY.md`.
- Add `SECURITY.md` to `exclude:` in `.rhiza/template.yml` (and mirror it in `template.lock`), making the file repo-owned.

## Why

The fuzzing claim was false. This repo has no `.clusterfuzzlite/` config and no `rhiza_fuzzing.yml` caller, so nothing fuzzes anything. A security policy that overstates the posture is worse than one that stays quiet.

Excluding the file follows from that. `SECURITY.md` ships in the template's `legal` bundle, but its **Security Measures** section is a set of factual claims about *this* repo — which scanners run, which release protections exist — and only the repo knows which hold. The template cannot, as the fuzzing line demonstrates.

Upstream applies the same standard to itself: `jebel-quant/rhiza` carries `tests/security/test_security_md_claims.py`, which parses each claim and demands evidence for it. That test ships in no bundle, so the responsibility lands here.

## Notes

The file stays on disk — this is an ownership change, not a removal. Empirically the template applies deltas rather than overwriting this file (a bespoke `SECURITY.md` elsewhere survived syncs from v1.2.0 through v1.4.2 untouched), so the exclusion is belt-and-braces that makes the intent explicit instead of relying on merge behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the security policy by removing the outdated fuzzing reference.
  * Ensured the repository’s security policy remains locally maintained rather than overwritten by the template.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->