### PR TITLE
fix: drop mkdocs nav entries for notebooks the book never builds

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,9 +16,3 @@ nav:
       - Sharpe pins: development/SHARPE_PINS.md
       - Tests: development/TESTS.md
       - Test layout: development/TEST_LAYOUT.md
-  - Notebooks:
-      - Experiment1: notebooks/Experiment1.html
-      - Experiment2: notebooks/Experiment2.html
-      - Experiment3: notebooks/Experiment3.html
-      - Experiment4: notebooks/Experiment4.html
-      - Experiment5: notebooks/Experiment5.html


### PR DESCRIPTION
Unblocks #538 (the rhiza v1.6.0 update), which fails `book / build`.

## What's wrong

`mkdocs.yml` navigated to five notebook pages the book never builds:

```yaml
- Notebooks:
    - Experiment1: notebooks/Experiment1.html
    ...
```

These have never resolved. Both paths are 404 on the live site right now:

- `https://tschm.github.io/cs/notebooks/Experiment1.html` → **404**
- `https://tschm.github.io/cs/marimo/notebooks/Experiment1.html` → **404** (the path `book/_toc.yml` links to)

The book build has been saying so all along, in a warning nothing gated on:

```
[WARN] no marimo folder; skipping notebook export
```

`rhiza-task` exports notebooks from `marimo_folder`. This repo never sets it, so it
resolves to the CLI default `docs/notebooks`, which doesn't exist here — the notebooks
live under `book/marimo/notebooks`, which is named by `source_folder`. The export
no-ops, and the five nav entries dangle.

rhiza v1.6.0 adds a `book-nav` gate that checks every nav target against the built
site, which is what surfaced this:

```
[ERROR] nav target not in the built book: notebooks/Experiment1.html
...
failed  book-nav  5 of 12 nav target(s) missing from '_book'
        -- the site would publish a 404 in its own navigation
```

## What this does

Removes the five entries, so the nav describes what the site actually publishes. The
remaining 7 nav targets all resolve. No other file changes.

## What this deliberately does *not* do

Make the notebooks publish. That looks like a one-line `marimo-folder` setting, but it
isn't:

- Both the exporter (`folder.glob("*.py")`) and `rhiza_marimo.yml`'s matrix
  (`find -maxdepth 1 -name "*.py"`) glob every Python file with no notebook filter.
- `book/marimo/notebooks` also holds `optimize.py` and `preamble.py`, which are plain
  modules, not marimo notebooks, and carry no PEP 723 header. The matrix runs
  `uv run --script` on each match, so it would go from 0 jobs to 7 with 2 failures.
- Separating them means moving `preamble.py` off the notebooks' `sys.path`, and all
  five notebooks plus `optimize.py` do `from preamble import …`. It would also touch
  the ty `extra-paths` headers, the 1:1 table in `docs/development/TEST_LAYOUT.md`,
  `scripts/check_test_layout.py`, and `source_folder`.

Worth doing as its own change if those pages should be on the site. Filed separately.
