### PR TITLE
fix: replace dead pages-build-deployment badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 📈 [The 10-line CTA](http://tschm.github.io/cs)
 
-[![pages-build-deployment](https://github.com/tschm/cs/actions/workflows/pages/pages-build-deployment/badge.svg)](https://github.com/tschm/cs/actions/workflows/pages/pages-build-deployment)
+[![Book](https://github.com/tschm/cs/actions/workflows/rhiza_book.yml/badge.svg)](https://github.com/tschm/cs/actions/workflows/rhiza_book.yml)
 [![CodeFactor](https://www.codefactor.io/repository/github/tschm/cs/badge)](https://www.codefactor.io/repository/github/tschm/cs)
 [![Coverage](https://tschm.github.io/cs/coverage-badge.svg)](https://tschm.github.io/cs/reports/html-coverage/)
 [![Renovate enabled](https://img.shields.io/badge/renovate-enabled-brightgreen.svg)](https://github.com/renovatebot/renovate)


### PR DESCRIPTION
## Problem

The weekly link check ([run 32705080000](https://github.com/tschm/cs/actions/runs/32705080000)) failed with a single lychee error:

```
[404] https://github.com/tschm/cs/actions/workflows/pages/pages-build-deployment (at 3:1) | Rejected status code: 404 Not Found
```

## Cause

`gh api repos/tschm/cs/pages` reports `"build_type": "workflow"` — Pages is deployed by `.github/workflows/rhiza_book.yml`, not by the classic `pages-build-deployment` job. That workflow does not exist for this repo, so both the badge image and its link were dead.

## Fix

Point the badge at the Book workflow instead. All URLs in `README.md` were then checked and return 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README book badge to link to the correct build workflow status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->